### PR TITLE
개선: 가게 마커 UI 개선 - 카카오맵 기본 파란색 마커로 변경, 선택 시 노란색 별표, 가게 이름 말풍선은 클릭 시에만 표시

### DIFF
--- a/src/components/map/StoreMarker.jsx
+++ b/src/components/map/StoreMarker.jsx
@@ -3,53 +3,48 @@ import { MapMarker, CustomOverlayMap } from 'react-kakao-maps-sdk'
 import defaultImage from '../../assets/images/luckeat-default.png'
 
 function StoreMarker({ store, isSelected, onClick }) {
-  // 카테고리에 따라 마커 색상 결정
-  const getCategoryColor = (category) => {
-    const categoryMap = {
-      한식: '#FF5733',
-      중식: '#C70039',
-      일식: '#0066CC',
-      양식: '#FFC300',
-      디저트: '#FF99CC',
-      패스트푸드: '#F4D03F',
-      분식: '#FF6347',
-      베이커리: '#D35400',
-      카페: '#7D3C98',
-      퓨전음식: '#8E44AD',
-      정육: '#C0392B',
-      수산: '#2980B9',
-      '야채/과일': '#27AE60',
-      '카페/디저트': '#FF69B4',
-      기타: '#95A5A6',
-    }
+  // 콘솔 로그 간소화
+  console.log('마커 생성:', store.id, store.name || store.storeName);
 
-    return categoryMap[category] || '#1E88E5' // 기본 색상
-  }
-
-  const categoryColor = getCategoryColor(store.category || '기타')
+  const handleStoreClick = (e) => {
+    e.stopPropagation();
+    window.location.href = `/store/${store.id}`;
+  };
 
   return (
     <React.Fragment>
+      {/* 가게 마커 - 파란색 마커 사용 */}
       <MapMarker
         position={{ lat: store.lat, lng: store.lng }}
-        onClick={onClick}
         image={{
-          src: 'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/markerStar.png',
-          size: { width: 24, height: 35 },
+          src: isSelected 
+            ? 'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/markerStar.png' // 선택 시 노란 별표 마커
+            : 'https://t1.daumcdn.net/localimg/localimages/07/2018/pc/img/marker_spot.png', // 기본 파란색 마커
+          size: isSelected ? { width: 24, height: 35 } : { width: 28, height: 40 },
         }}
+        onClick={onClick}
+        title={store.name || store.storeName}
       />
 
+      {/* 마커 정보 오버레이 - 선택했을 때만 표시 */}
       {isSelected && (
         <CustomOverlayMap
           position={{ lat: store.lat, lng: store.lng }}
           yAnchor={1.2}
+          zIndex={20}
         >
-          <div className="bg-white p-3 rounded-lg shadow-lg border max-w-xs">
+          <div className="bg-white p-3 rounded-lg shadow-lg border max-w-xs relative">
+            {/* 화살표 */}
+            <div 
+              className="absolute top-0 left-1/2 transform -translate-x-1/2 -translate-y-full"
+              style={{ width: 0, height: 0, borderLeft: '8px solid transparent', borderRight: '8px solid transparent', borderBottom: '8px solid white' }}
+            />
+            
             <div className="flex items-start gap-3">
               <div className="w-16 h-16 bg-gray-200 rounded overflow-hidden flex-shrink-0">
                 <img
                   src={defaultImage}
-                  alt={store.name}
+                  alt={store.name || store.storeName}
                   className="w-full h-full object-cover"
                   crossOrigin="anonymous"
                   onError={(e) => {
@@ -59,7 +54,13 @@ function StoreMarker({ store, isSelected, onClick }) {
                 />
               </div>
               <div className="flex-1 min-w-0">
-                <h4 className="font-bold text-sm truncate">{store.name}</h4>
+                <h4 className="font-bold text-sm truncate">{store.name || store.storeName}</h4>
+                <div 
+                  className="text-xs mt-1 px-2 py-1 rounded inline-block"
+                  style={{ backgroundColor: '#E3F2FD', color: '#1E88E5' }}
+                >
+                  {store.category || '기타'}
+                </div>
                 <p className="text-xs text-gray-500 mt-1 truncate">
                   {store.address || '주소 정보 없음'}
                 </p>
@@ -74,11 +75,8 @@ function StoreMarker({ store, isSelected, onClick }) {
                   </p>
                 )}
                 <button
-                  className="mt-2 w-full bg-yellow-500 text-white text-xs py-1 px-2 rounded"
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    window.location.href = `/store/${store.id}`
-                  }}
+                  className="mt-2 w-full bg-blue-500 hover:bg-blue-600 text-white text-xs py-1 px-2 rounded transition-colors"
+                  onClick={handleStoreClick}
                 >
                   가게 상세보기
                 </button>


### PR DESCRIPTION
### Description

지도 페이지에서 가게 목록과 지도 위에 마커를 표시하고, 마커 클릭 시 가게 이름이 나타나며 해당 가게의 상세 페이지로 이동할 수 있도록 구현함.

### Related Issues

- Resolves #[이슈 번호]

### Changes Made

1. 지도 페이지에 가게 목록을 불러와서 표시함.
2. 지도 위에 가게 위치에 맞는 마커를 추가함.
3. 마커 클릭 시 해당 가게의 이름이 표시되도록 구현함.
4. 가게 이름을 클릭하면 상세 페이지로 이동하도록 설정함.

### Screenshots or Video

변경 사항이 UI에 영향을 미치므로, 아래 스크린샷을 참고.

<!-- 스크린샷 또는 동영상 첨부 -->

### Testing

1. 지도 페이지에 정상적으로 가게 목록이 나타나는지 확인함.
2. 지도에 마커가 올바르게 표시되는지 테스트함.
3. 마커 클릭 시 가게 이름이 정상적으로 표시되는지 확인함.
4. 가게 이름 클릭 시 상세 페이지로 정상 이동하는지 테스트함.

### Checklist

- [ ] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [ ] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [ ] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 코드 리뷰어를 지정했습니다.

### Additional Notes

추가적인 테스트나 코드 개선이 필요한 부분이 있으면 피드백 부탁드립니다.
