### PR TITLE
42 feat 클라우드프론트 개발운영환경 분리/siena

### DIFF
--- a/.github/workflows/s3-deploy.yml
+++ b/.github/workflows/s3-deploy.yml
@@ -1,9 +1,10 @@
-name: Deploy to S3
+name: 🚀 Deploy to S3
 
 on:
   push:
     branches:
-      - main # 또는 master 등 배포하고 싶은 브랜치 지정
+      - main
+      - dev
 
 jobs:
   deploy:
@@ -11,6 +12,17 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        
+      - name: Set environment variables
+        run: |
+          if [[ $GITHUB_REF == 'refs/heads/main' ]]; then
+            echo "ENVIRONMENT=production" >> $GITHUB_ENV
+            echo "CLOUDFRONT_ID=${{ secrets.CLOUDFRONT_DISTRIBUTION_ID_PROD }}" >> $GITHUB_ENV
+          else
+            echo "ENVIRONMENT=development" >> $GITHUB_ENV
+            echo "CLOUDFRONT_ID=${{ secrets.CLOUDFRONT_DISTRIBUTION_ID_DEV }}" >> $GITHUB_ENV
+          fi
+          echo "Deploying to $ENVIRONMENT environment"
 
       - name: Set up Node.js
         uses: actions/setup-node@v3
@@ -59,14 +71,27 @@ jobs:
       - name: Deploy to S3
         run: |
           if [ -d "build" ]; then
-            echo "Deploying from build directory..."
-            aws s3 sync ./build s3://luckeat-front --exclude "images/*" --exclude "store/*"
+            echo "Deploying from build directory to ${{ env.ENVIRONMENT }} environment..."
+            if [[ "${{ env.ENVIRONMENT }}" == "production" ]]; then
+              aws s3 sync ./build s3://luckeat-front/production --exclude "images/*" --exclude "store/*"
+            else
+              aws s3 sync ./build s3://luckeat-front/development --exclude "images/*" --exclude "store/*"
+            fi
           elif [ -d "dist" ]; then
-            echo "Deploying from dist directory..."
-            aws s3 sync ./dist s3://luckeat-front --exclude "images/*" --exclude "store/*"
+            echo "Deploying from dist directory to ${{ env.ENVIRONMENT }} environment..."
+            if [[ "${{ env.ENVIRONMENT }}" == "production" ]]; then
+              aws s3 sync ./dist s3://luckeat-front/production --exclude "images/*" --exclude "store/*"
+            else
+              aws s3 sync ./dist s3://luckeat-front/development --exclude "images/*" --exclude "store/*"
+            fi
           else
             echo "No build directory found. Please check your build configuration."
             exit 1
           fi
-          echo "Deployment completed successfully"
-        # 빌드 결과물이 있는 디렉토리(예: ./build 또는 ./dist)와 S3 버킷 이름을 적절히 변경하세요
+          echo "Deployment to ${{ env.ENVIRONMENT }} completed successfully"
+
+      - name: Invalidate CloudFront Cache
+        run: |
+          echo "Invalidating CloudFront distribution cache for ${{ env.ENVIRONMENT }}..."
+          aws cloudfront create-invalidation --distribution-id ${{ env.CLOUDFRONT_ID }} --paths "/*"
+          echo "CloudFront cache invalidation completed for ${{ env.ENVIRONMENT }}"

--- a/vite.config.js
+++ b/vite.config.js
@@ -28,7 +28,7 @@ export default defineConfig({
   },
   build: {
     rollupOptions: {
-      external: ['react-kakao-maps-sdk'],
+      //external: ['react-kakao-maps-sdk'],
     },
   },
 })


### PR DESCRIPTION
### Description

브랜치(main/dev)에 따라 S3 버킷 내 서로 다른 폴더에 `index.html`이 저장되도록 배포 프로세스를 수정했습니다.  
또한, 운영환경과 개발환경을 구분하여 각각의 CloudFront 배포를 구성하고, 배포 후 자동으로 캐시 무효화가 이루어지도록 설정했습니다.

### Related Issues

- Closes #42 

### Changes Made

1. GitHub Actions 워크플로우에서 브랜치에 따라 `production`, `development` 환경 변수 설정
2. S3 버킷에 `build` 결과물을 브랜치에 따라 각각 다른 폴더(`luckeat-front/production`, `luckeat-front/development`)로 업로드
3. CloudFront 배포를 각각 분리하여 운영/개발 환경을 구성
4. 배포 완료 후 해당 환경의 CloudFront 캐시를 자동으로 무효화하도록 설정

### Screenshots or Video

<!--
변경된 사항이 UI에 영향을 미치는 경우, 변경 전후의 스크린샷이나 동영상을 첨부하세요.
-->

### Testing

### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [ ] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [ ] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

### Additional Notes

- AWS S3, CloudFront 관련 IAM 권한 및 비밀 키는 GitHub Secrets에 등록된 값을 사용합니다.
- 배포 대상 디렉토리는 `build` 또는 `dist` 기준이며, 프로젝트 빌드 설정에 따라 유동적으로 대응합니다.