### PR TITLE
카테고리 아이콘 필터 클릭 시 노란색 강조 및 전체 기본 선택 설정

### DIFF
--- a/src/components/store/CategoryList.jsx
+++ b/src/components/store/CategoryList.jsx
@@ -26,20 +26,27 @@ function CategoryList({ categories = [], selectedCategory, onSelectCategory }) {
     ...(categories || []),
   ]
 
+  // selectedCategory가 없으면 '전체' 카테고리가 선택된 것으로 처리
+  const isAllSelected = selectedCategory === '' || selectedCategory === null || selectedCategory === undefined;
+
   return (
     <div className="grid grid-cols-4 gap-2 p-4 bg-gray-100">
       {allCategories.map((category) => {
         // 백엔드 API의 카테고리 필드명에 맞게 수정
         const categoryName = category.categoryName
         const icon = categoryIcons[categoryName] || '🍴' // 기본 아이콘
+        
+        // 선택 상태 확인 - '전체' 카테고리는 selectedCategory가 비어있을 때 선택됨
+        const isSelected = 
+          category.categoryName === '전체' 
+            ? isAllSelected
+            : selectedCategory === category.id || selectedCategory === String(category.id);
 
         return (
           <button
             key={category.id}
             className={`flex flex-col items-center ${
-              selectedCategory === String(category.id)
-                ? 'text-yellow-500'
-                : 'text-gray-700'
+              isSelected ? 'text-yellow-500' : 'text-gray-700'
             }`}
             onClick={() =>
               onSelectCategory(categoryName === '전체' ? '' : category.id)
@@ -47,9 +54,7 @@ function CategoryList({ categories = [], selectedCategory, onSelectCategory }) {
           >
             <div
               className={`w-14 h-14 rounded-full flex items-center justify-center mb-1 ${
-                selectedCategory === String(category.id)
-                  ? 'bg-yellow-100'
-                  : 'bg-gray-200'
+                isSelected ? 'bg-yellow-100' : 'bg-gray-200'
               }`}
             >
               <span className="text-2xl">{icon}</span>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -212,7 +212,7 @@ function HomePage() {
   // 카테고리 핸들러
   const handleCategorySelect = (category) => {
     console.log('카테고리 선택:', category)
-    setSelectedCategory(category)
+    setSelectedCategory(category === selectedCategory ? '' : category)
   }
 
   // HomePage.jsx 파일에서 가게 카드 클릭 핸들러 추가
@@ -306,7 +306,7 @@ function HomePage() {
         <CategoryList
           categories={categories}
           selectedCategory={selectedCategory}
-          onSelectCategory={setSelectedCategory}
+          onSelectCategory={handleCategorySelect}
         />
       </div>
 


### PR DESCRIPTION


### Description

메인페이지에서 가게 카테고리를 나타내는 이모티콘 필터링 버튼 클릭 시  
노란색으로 강조되도록 수정했고, '전체' 카테고리가 항상 기본 선택되도록 개선했습니다

**문제 원인**  
- 선택 상태 표시 로직 불완전: 카테고리 아이콘 선택 상태를 확인하는 로직이 불완전했고, 문자열과 숫자 타입 비교 시 오류 발생  
- '전체' 카테고리 선택 상태 처리 미흡: 기본 선택 상태임에도 시각적 표시가 명확하지 않았음  

**수정 내용**  
- `CategoryList.jsx`  
  - `isAllSelected` 변수 추가하여 빈 문자열, null, undefined일 경우 '전체' 선택 처리  
  - 각 카테고리 버튼의 `isSelected` 상태 로직 추가  
  - '전체'와 일반 카테고리의 선택 처리 분리  
  - 선택된 카테고리 텍스트와 아이콘에 노란색 배경 스타일 적용  

- `HomePage.jsx`  
  - `selectedCategory` 상태 초기값을 빈 문자열('')로 설정하여 '전체'가 기본 선택되도록 함  
  - `handleCategorySelect` 함수에서 같은 카테고리 재클릭 시 '전체'로 초기화되도록 로직 개선  
  - `onSelectCategory`로 `handleCategorySelect` 전달하여 클릭 처리 일원화  

이러한 수정을 통해 현재 선택된 카테고리를 사용자에게 명확히 보여주고, UX를 개선했습니다  

### Related Issues

- Resolves #45

### Changes Made

1. `CategoryList.jsx`: 선택 상태 구분 로직 추가 및 스타일 적용  
2. `HomePage.jsx`: 기본 선택 상태 설정 및 카테고리 선택 로직 개선  
3. UX 관점에서 동일 카테고리 클릭 시 '전체'로 리셋되는 로직 추가  

### Screenshots or Video

_(해당 없음)_

### Testing

1. 페이지 진입 시 '전체' 카테고리 노란색 표시 여부 확인  
2. 카테고리 버튼 클릭 시 해당 아이콘과 텍스트가 노란색으로 강조되는지 확인  
3. 같은 카테고리 클릭 시 다시 '전체'로 초기화되는지 테스트  

### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다  
- [x] 모든 테스트가 성공적으로 통과했습니다  
- [x] 관련 문서를 업데이트했습니다  
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다  
- [x] 코드 스타일 가이드라인을 준수했습니다  
- [x] 코드 리뷰어를 지정했습니다  

### Additional Notes

- 이후 카테고리 스타일 통일 및 반응형 대응 작업 필요
