### PR TITLE
fix: API 상대경로 사용

### DIFF
--- a/src/api/apiClient.js
+++ b/src/api/apiClient.js
@@ -1,6 +1,8 @@
 import axios from 'axios'
 import { handleErrorResponse, ERROR_MESSAGES } from '../utils/apiMessages'
-import { API_BASE_URL } from '../config/apiConfig'
+
+// API 접두사 설정
+const API_PREFIX = '/api/v1'
 
 // 토큰 관련 상수
 export const TOKEN_KEYS = {
@@ -10,7 +12,6 @@ export const TOKEN_KEYS = {
 
 // axios 인스턴스 생성
 const apiClient = axios.create({
-  baseURL: API_BASE_URL,
   headers: {
     'Content-Type': 'application/json',
     'Access-Control-Allow-Origin': '*',
@@ -22,6 +23,15 @@ const apiClient = axios.create({
 // 요청 인터셉터 설정
 apiClient.interceptors.request.use(
   (config) => {
+    // API 접두사 추가
+    if (
+      config.url &&
+      !config.url.startsWith('/api/v1') &&
+      !config.url.startsWith('http')
+    ) {
+      config.url = `${API_PREFIX}${config.url}`
+    }
+
     // 로컬 스토리지에서 토큰 가져오기
     const token = localStorage.getItem('accessToken')
     if (token) {

--- a/src/config/apiConfig.js
+++ b/src/config/apiConfig.js
@@ -1,5 +1,5 @@
 // API 설정 파일
-const API_BASE_URL = 'https://3.34.255.222:8080/api/v1'
+const API_BASE_URL = '/api/v1'
 const API_DIRECT_URL = 'https://3.34.255.222:8080'
 
 // API 엔드포인트

--- a/vite.config.js
+++ b/vite.config.js
@@ -12,7 +12,7 @@ export default defineConfig({
     port: 3000,
     proxy: {
       '/api': {
-        target: 'https://3.34.255.222:8080',
+        target: 'http://3.34.255.222:8080',
         changeOrigin: true,
         secure: false,
         ws: true,


### PR DESCRIPTION
### Description

직접 EC2주소를 사용해서 요청을 보내던 코드(인증서를 거치지않아서 요청이 거부됨)를 상대경로로 수정하였습니다.
상대경로를 통해 cloudfront를 거쳐 요청을 보내도록 구성하였습니다.


### Related Issues

- Clouses #46 

### Changes Made

1. modified:   src/api/apiClient.js
3. modified:   src/config/apiConfig.js
4. modified:   vite.config.js

상대경로 사용하도록 수정하였습니다.

### Screenshots or Video

없음

### Testing

로컬에서 빌드테스트를 수행하였습니다.

### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

### Additional Notes

<!--
  리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요.
-->
