### PR TITLE
feat: 카테고리 선택 유지

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -16,7 +16,15 @@ function HomePage() {
   const [stores, setStores] = useState([])
   const [categories, setCategories] = useState([])
   const [filteredStores, setFilteredStores] = useState([])
-  const [selectedCategory, setSelectedCategory] = useState('')
+  const [selectedCategory, setSelectedCategory] = useState(() => {
+    // 세션 스토리지에서 저장된 카테고리 상태를 불러옴
+    const savedCategory = sessionStorage.getItem('selectedCategory')
+    // 문자열로 저장된 숫자 ID를 적절히 변환
+    if (savedCategory === '') return ''
+    if (savedCategory === null || savedCategory === undefined) return ''
+    // 숫자 형태의 문자열을 반환
+    return savedCategory
+  })
   const [showScrollTopButton, setShowScrollTopButton] = useState(false)
   const [sortOption, setSortOption] = useState('가까운 순')
   const [showSortOptions, setShowSortOptions] = useState(false)
@@ -130,8 +138,12 @@ function HomePage() {
     // 카테고리 필터링 - 백엔드 API 응답 구조에 맞게 수정
     if (selectedCategory) {
       result = result.filter((store) => {
-        // categoryId를 비교 (API 응답 구조에 맞게 수정)
-        return store.categoryId === selectedCategory
+        // categoryId를 비교 (string과 number 모두 처리)
+        return (
+          store.categoryId === selectedCategory ||
+          store.categoryId === Number(selectedCategory) ||
+          String(store.categoryId) === selectedCategory
+        )
       })
       console.log('카테고리 필터링 후 가게 수:', result.length)
     }
@@ -208,7 +220,10 @@ function HomePage() {
   // 카테고리 핸들러
   const handleCategorySelect = (category) => {
     console.log('카테고리 선택:', category)
-    setSelectedCategory(category === selectedCategory ? '' : category)
+    const newCategoryValue = category === selectedCategory ? '' : category
+    setSelectedCategory(newCategoryValue)
+    // 선택된 카테고리 상태를 세션 스토리지에 저장 (문자열로 통일)
+    sessionStorage.setItem('selectedCategory', String(newCategoryValue))
   }
 
   // HomePage.jsx 파일에서 가게 카드 클릭 핸들러 추가


### PR DESCRIPTION
### Description

- 카테고리를 선택한 후 다른 페이지로 이동하거나 새로고침했을 때, 선택된 카테고리 상태가 초기화되어 풀리는 문제가 있었습니다.
- 세션 스토리지를 활용하여 카테고리 선택 상태를 유지하고 페이지 로드 시 자동으로 복원하도록 구현했습니다.

### Related Issues

- closes #60 
 

### Screenshots or Video

- 카테고리 중식 선택 
<img width="521" alt="스크린샷 2025-03-24 오후 5 37 08" src="https://github.com/user-attachments/assets/b9dbefc5-b050-4e97-a690-2c65256c1fff" />

- 새로고침 후 선택 사항 유지
<img width="521" alt="스크린샷 2025-03-24 오후 5 37 08" src="https://github.com/user-attachments/assets/917ff2cb-1b8e-45f5-b77a-504ebbafe594" />


### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.
