### PR TITLE
[FE] 홈페이지 및 가게 상세페이지 스크롤 버튼 위치 조정

### DIFF
--- a/src/components/common/ScrollTopButton.jsx
+++ b/src/components/common/ScrollTopButton.jsx
@@ -1,56 +1,64 @@
-import { useState, useEffect } from 'react'
+import React, { useState, useEffect } from 'react'
 
-function ScrollTopButton() {
-  const [showScrollTopButton, setShowScrollTopButton] = useState(false)
+function ScrollTopButton({ scrollContainerRef }) {
+  const [isVisible, setIsVisible] = useState(false)
 
-  // 스크롤 이벤트 핸들러
   useEffect(() => {
+    const scrollContainer = scrollContainerRef?.current
+    if (!scrollContainer) return
+
     const handleScroll = () => {
-      setShowScrollTopButton(window.scrollY > 300)
+      setIsVisible(scrollContainer.scrollTop > 100)
     }
 
-    // 이벤트 리스너 추가
-    window.addEventListener('scroll', handleScroll)
+    scrollContainer.addEventListener('scroll', handleScroll)
+    handleScroll()
 
-    // 클린업 함수
     return () => {
-      window.removeEventListener('scroll', handleScroll)
+      scrollContainer.removeEventListener('scroll', handleScroll)
     }
-  }, [])
+  }, [scrollContainerRef])
 
   const scrollToTop = () => {
-    window.scrollTo({
-      top: 0,
-      behavior: 'smooth',
-    })
+    if (scrollContainerRef?.current) {
+      scrollContainerRef.current.scrollTo({
+        top: 0,
+        behavior: 'smooth',
+      })
+    }
   }
 
   return (
-    <>
-      {showScrollTopButton && (
-        <button
-          onClick={scrollToTop}
-          className="fixed bottom-24 right-6 bg-yellow-500 text-white w-10 h-10 rounded-full flex items-center justify-center shadow-lg z-50 hover:bg-yellow-600"
-          aria-label="맨 위로 스크롤"
+    <div
+      className="fixed left-1/2 transform translate-x-[220%] z-[9999]"
+      style={{
+        bottom: '110px', // 네비게이션 바 위 여백
+      }}
+    >
+      <button
+        onClick={scrollToTop}
+        className={`bg-yellow-500 text-white w-12 h-12 rounded-full flex items-center justify-center shadow-lg hover:bg-yellow-600 transition-all duration-300 ${
+          isVisible ? 'opacity-100' : 'opacity-0 pointer-events-none'
+        }`}
+        aria-label="맨 위로 스크롤"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          className="h-6 w-6"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
         >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            className="h-6 w-6"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M5 10l7-7m0 0l7 7m-7-7v18"
-            />
-          </svg>
-        </button>
-      )}
-    </>
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M5 10l7-7m0 0l7 7m-7-7v18"
+          />
+        </svg>
+      </button>
+    </div>
   )
 }
 
-export default ScrollTopButton 
+export default ScrollTopButton

--- a/src/components/common/ScrollTopButton.jsx
+++ b/src/components/common/ScrollTopButton.jsx
@@ -1,0 +1,56 @@
+import { useState, useEffect } from 'react'
+
+function ScrollTopButton() {
+  const [showScrollTopButton, setShowScrollTopButton] = useState(false)
+
+  // 스크롤 이벤트 핸들러
+  useEffect(() => {
+    const handleScroll = () => {
+      setShowScrollTopButton(window.scrollY > 300)
+    }
+
+    // 이벤트 리스너 추가
+    window.addEventListener('scroll', handleScroll)
+
+    // 클린업 함수
+    return () => {
+      window.removeEventListener('scroll', handleScroll)
+    }
+  }, [])
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    })
+  }
+
+  return (
+    <>
+      {showScrollTopButton && (
+        <button
+          onClick={scrollToTop}
+          className="fixed bottom-24 right-6 bg-yellow-500 text-white w-10 h-10 rounded-full flex items-center justify-center shadow-lg z-50 hover:bg-yellow-600"
+          aria-label="맨 위로 스크롤"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-6 w-6"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M5 10l7-7m0 0l7 7m-7-7v18"
+            />
+          </svg>
+        </button>
+      )}
+    </>
+  )
+}
+
+export default ScrollTopButton 

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -10,6 +10,7 @@ import homepageImage2 from '../assets/images/Homepagr_2.png'
 import homepageImage3 from '../assets/images/Hompage_2.jpg'
 import storeDefaultImage from '../assets/images/제빵사디폴트이미지.png'
 import SearchBar from '../components/Search/SearchBar'
+import ScrollTopButton from '../components/common/ScrollTopButton'
 
 function HomePage() {
   const navigate = useNavigate()
@@ -108,9 +109,7 @@ function HomePage() {
   console.log('현재 상태 - 로딩:', loading, '데이터:', stores)
 
   const handleScroll = () => {
-    if (storeListRef.current) {
-      setShowScrollTopButton(storeListRef.current.scrollTop > 300)
-    }
+    // 스크롤 이벤트는 유지하되 맨 위로 버튼 관련 코드 제거
   }
 
   const scrollToTop = () => {
@@ -533,30 +532,9 @@ function HomePage() {
             </div>
           )}
         </div>
-
-        {showScrollTopButton && (
-          <button
-            onClick={scrollToTop}
-            className="fixed bottom-24 left-1/2 transform -translate-x-1/2 translate-x-28 bg-yellow-500 text-white w-10 h-10 rounded-full flex items-center justify-center shadow-lg z-10 hover:bg-yellow-600 scroll-container"
-            aria-label="맨 위로 스크롤"
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              className="h-6 w-6"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M5 10l7-7m0 0l7 7m-7-7v18"
-              />
-            </svg>
-          </button>
-        )}
       </div>
+
+      <ScrollTopButton />
 
       <div className="w-full bg-white border-t">
         <Navigation />

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -225,7 +225,7 @@ function HomePage() {
   }
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col h-full relative">
       <div className="px-4 py-3 border-b flex justify-center items-center bg-white sticky top-0 z-30">
         <h1
           className="text-2xl font-bold text-yellow-500"
@@ -534,7 +534,7 @@ function HomePage() {
         </div>
       </div>
 
-      <ScrollTopButton />
+      <ScrollTopButton scrollContainerRef={storeListRef} />
 
       <div className="w-full bg-white border-t">
         <Navigation />

--- a/src/pages/StoreDetailPage.jsx
+++ b/src/pages/StoreDetailPage.jsx
@@ -182,7 +182,7 @@ function StoreDetailPage() {
     store.products?.filter((product) => !product.isOpen) || []
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col h-full relative">
       <Header title={store.storeName} />
 
       <div 
@@ -618,10 +618,10 @@ function StoreDetailPage() {
             </p>
           )}
         </div>
-
-        {/* ScrollTopButton 컴포넌트 추가 */}
-        <ScrollTopButton />
       </div>
+
+      {/* 맨 위로 버튼 - div 외부에 배치하여 항상 보이도록 */}
+      <ScrollTopButton scrollContainerRef={mainContainerRef} />
 
       {/* 전화번호 팝업 */}
       {showPhonePopup && (

--- a/src/pages/StoreDetailPage.jsx
+++ b/src/pages/StoreDetailPage.jsx
@@ -6,6 +6,7 @@ import { Map, MapMarker } from 'react-kakao-maps-sdk' //카카오맵 추가
 import { getStoreById } from '../api/storeApi'
 import defaultImage from '../assets/images/luckeat-default.png'
 import bakerDefaultImage from '../assets/images/제빵사디폴트이미지.png'
+import ScrollTopButton from '../components/common/ScrollTopButton'
 
 function StoreDetailPage() {
   const { id } = useParams()
@@ -122,18 +123,7 @@ function StoreDetailPage() {
 
   // 스크롤 관련 함수
   const handleScroll = () => {
-    if (mainContainerRef.current) {
-      setShowScrollTopButton(mainContainerRef.current.scrollTop > 300)
-    }
-  }
-
-  const scrollToTop = () => {
-    if (mainContainerRef.current) {
-      mainContainerRef.current.scrollTo({
-        top: 0,
-        behavior: 'smooth',
-      })
-    }
+    // 스크롤 이벤트는 유지하되 맨 위로 버튼 관련 코드 제거
   }
 
   // 탭 클릭 시 해당 섹션으로 스크롤
@@ -629,29 +619,8 @@ function StoreDetailPage() {
           )}
         </div>
 
-        {/* 맨 위로 버튼 */}
-        {showScrollTopButton && (
-          <button
-            onClick={scrollToTop}
-            className="fixed bottom-24 left-1/2 transform -translate-x-1/2 translate-x-28 bg-yellow-500 text-white w-10 h-10 rounded-full flex items-center justify-center shadow-lg z-10 hover:bg-yellow-600"
-            aria-label="맨 위로 스크롤"
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              className="h-6 w-6"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M5 10l7-7m0 0l7 7m-7-7v18"
-              />
-            </svg>
-          </button>
-        )}
+        {/* ScrollTopButton 컴포넌트 추가 */}
+        <ScrollTopButton />
       </div>
 
       {/* 전화번호 팝업 */}


### PR DESCRIPTION
# [FE] 홈페이지 및 가게 상세페이지 스크롤 버튼 위치 조정

## 📌 어떤 기능인가요?

홈페이지와 가게 상세페이지에 있는 ‘위로 가기’ 버튼의 위치를 사용자의 시야와 편의성을 고려해 고정 및 정렬 조정

---

## ✅ 작업 상세 내용

- [ ] 홈페이지 위로 가는 버튼의 위치 정적으로 고정
- [ ] 가게 상세페이지 위로 가는 버튼 위치 고정
- [ ] 버튼이 다른 UI 요소와 겹치지 않도록 margin/padding 조정
- [ ] 모바일에서도 위치가 일관되도록 반응형 처리

---

## 📎 참고할만한 자료 (선택)

> 없음

---

## 🎯 예상 마감일

- `2025-03-28`

---

## 🏷 관련 이슈 (선택)

> 없음

---

👀 **추가 설명이 필요한 경우, 아래에 자유롭게 작성해주세요!**

- 스크롤을 많이 내렸을 때도 항상 우측 하단에서 접근 가능하도록 배치  
- 브랜치명: `Feature/scroll top button`
