### PR TITLE
fix: 개발/운영 환경에 따른 API URL 분리 설정

### DIFF
--- a/src/api/apiClient.js
+++ b/src/api/apiClient.js
@@ -32,13 +32,13 @@ apiClient.interceptors.request.use(
       // URL 통합 처리
       if (config.url.startsWith('/v1/')) {
         // /v1/로 시작하는 경우 - /api를 추가하고 도메인 추가
-        config.url = `https://luckeat.net/api${config.url}`
+        config.url = `${process.env.NODE_ENV === 'development' ? 'https://dxa66rf338pjr.cloudfront.net' : 'https://luckeat.net'}/api${config.url}`
       } else if (config.url.startsWith('/api/')) {
         // /api/로 시작하는 경우 - 그대로 도메인만 추가
-        config.url = `https://luckeat.net${config.url}`
+        config.url = `${process.env.NODE_ENV === 'development' ? 'https://dxa66rf338pjr.cloudfront.net' : 'https://luckeat.net'}${config.url}`
       } else {
         // 그 외 - 모든 API 엔드포인트는 /api/v1/로 시작하도록 설정
-        config.url = `https://luckeat.net/api/v1${config.url.startsWith('/') ? '' : '/'}${config.url}`
+        config.url = `${process.env.NODE_ENV === 'development' ? 'https://dxa66rf338pjr.cloudfront.net' : 'https://luckeat.net'}/api/v1${config.url.startsWith('/') ? '' : '/'}${config.url}`
       }
     }
 

--- a/src/config/apiConfig.js
+++ b/src/config/apiConfig.js
@@ -1,6 +1,13 @@
 // API 설정 파일
-const API_BASE_URL = 'https://luckeat.net/api/v1'
-const API_DIRECT_URL = 'https://luckeat.net'
+const isDevelopment = process.env.NODE_ENV === 'development'
+
+const API_BASE_URL = isDevelopment 
+  ? 'https://dxa66rf338pjr.cloudfront.net/api/v1'
+  : 'https://luckeat.net/api/v1'
+
+const API_DIRECT_URL = isDevelopment
+  ? 'https://dxa66rf338pjr.cloudfront.net'
+  : 'https://luckeat.net'
 
 // API 엔드포인트
 const API_ENDPOINTS = {

--- a/vite.config.js
+++ b/vite.config.js
@@ -12,7 +12,7 @@ export default defineConfig({
     port: 3000,
     proxy: {
       '/api': {
-        target: 'https://luckeat.net',
+        target: 'https://dxa66rf338pjr.cloudfront.net',
         changeOrigin: true,
         secure: true,
         ws: true,


### PR DESCRIPTION
### Description

개발 환경과 운영 환경에서 다른 API URL을 사용하도록 설정을 변경했습니다. 
개발 환경에서는 CloudFront URL을, 운영 환경에서는 luckeat.net 도메인을 사용합니다.

### Related Issues
- Closes #96

### Changes Made
1. `src/config/apiConfig.js`: 환경에 따른 API URL 분리 설정
   - 개발 환경: `https://dxa66rf338pjr.cloudfront.net/api/v1`
   - 운영 환경: `https://luckeat.net/api/v1`

2. `vite.config.js`: 개발 서버 프록시 설정을 CloudFront URL로 변경
   - target URL을 `https://dxa66rf338pjr.cloudfront.net`으로 수정

3. `src/api/apiClient.js`: axios 인스턴스의 URL 설정을 환경에 따라 다르게 처리하도록 수정
   - 환경 변수에 따라 다른 도메인으로 요청이 전송되도록 수정

### Testing
1. 개발 환경에서 API 요청 테스트
   - `curl -v https://dxa66rf338pjr.cloudfront.net/api/v1/stores` 요청 성공
   - 가게 목록 데이터 정상 반환 확인

2. 환경 변수 설정 확인
   - `process.env.NODE_ENV`가 'development'일 때 CloudFront URL 사용
   - `process.env.NODE_ENV`가 'production'일 때 luckeat.net URL 사용

3. 개발 서버 재시작 후 API 요청 테스트
   - 가게 목록 조회 정상 작동 확인
   - 다른 API 엔드포인트도 정상 작동 확인

### Checklist
- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.

### Additional Notes
- 개발 환경과 운영 환경의 API URL이 분리되어 있어 각 환경에 맞는 요청이 전송됩니다.
- CloudFront 캐시 관련 이슈가 해결될 것으로 예상됩니다.
- 해결안될 수 있음 노여워마시고 기다려주세요ㅠㅅㅠ