### PR TITLE
fix: 스토어 이미지가 제대로 표시되도록 수정

### DIFF
--- a/src/components/map/StoreMarker.jsx
+++ b/src/components/map/StoreMarker.jsx
@@ -52,7 +52,7 @@ function StoreMarker({ store, isSelected, onClick }) {
             <div className="flex items-start gap-3">
               <div className="w-16 h-16 bg-gray-200 rounded overflow-hidden flex-shrink-0">
                 <img
-                  src={store.imageUrl || storeDefaultImage}
+                  src={store.storeImg ? store.storeImg : (store.imageUrl || storeDefaultImage)}
                   alt={store.name || store.storeName}
                   className="w-full h-full object-cover"
                   crossOrigin="anonymous"

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -491,7 +491,7 @@ function HomePage() {
               >
                 <div className="w-16 h-16 bg-gray-200 rounded-md overflow-hidden">
                   <img
-                    src={storeDefaultImage}
+                    src={store.storeImg ? store.storeImg : storeDefaultImage}
                     alt={store.storeName || store.name || '가게 이미지'}
                     className="w-full h-full object-cover"
                     crossOrigin="anonymous"

--- a/src/pages/MapPage.jsx
+++ b/src/pages/MapPage.jsx
@@ -690,7 +690,7 @@ function MapPage() {
                   >
                     <div className="w-12 h-12 bg-gray-200 rounded-md mr-3">
                       <img
-                        src={store.imageUrl || storeDefaultImage}
+                        src={store.storeImg ? store.storeImg : (store.imageUrl || storeDefaultImage)}
                         alt={store.name || store.storeName}
                         className="w-full h-full object-cover rounded-md"
                         crossOrigin="anonymous"

--- a/src/pages/StoreDetailPage.jsx
+++ b/src/pages/StoreDetailPage.jsx
@@ -192,7 +192,7 @@ function StoreDetailPage() {
       >
         {/* 가게 이미지 */}
         <img
-          src={store.storeImg || defaultImage}
+          src={store.storeImg ? store.storeImg : defaultImage}
           alt={store.storeName}
           className="w-full h-48 object-cover"
           crossOrigin="anonymous"
@@ -378,7 +378,9 @@ function StoreDetailPage() {
                 <img
                   src={
                     product.productImg
-                      ? `https://dxflvza4ey8e9.cloudfront.net/product/${product.productImg}`
+                      ? product.productImg.startsWith('http')
+                        ? product.productImg
+                        : `https://dxflvza4ey8e9.cloudfront.net/product/${product.productImg}`
                       : bakerDefaultImage
                   }
                   alt={product.productName}
@@ -425,7 +427,9 @@ function StoreDetailPage() {
                     <img
                       src={
                         product.productImg
-                          ? `https://dxflvza4ey8e9.cloudfront.net/product/${product.productImg}`
+                          ? product.productImg.startsWith('http')
+                            ? product.productImg
+                            : `https://dxflvza4ey8e9.cloudfront.net/product/${product.productImg}`
                           : bakerDefaultImage
                       }
                       alt={product.productName}


### PR DESCRIPTION
### Description

가게 상세 페이지 및 리스트에서 이미지가 항상 디폴트 이미지로만 표시되던 문제를 수정함  
가게별 실제 이미지가 있을 경우 정상적으로 표시되도록 조건 분기 및 로직을 개선함

### Related Issues

- Resolves #[이슈 번호를 여기에 입력하세요]

### Changes Made

1. 가게 이미지 렌더링 로직 수정
   - 이미지 URL이 유효할 경우 해당 이미지 표시
   - 이미지가 없거나 로딩 실패 시에만 디폴트 이미지 사용
2. 이미지 로드 오류 처리 개선 (`onError` 핸들러 사용 등)

### Screenshots or Video

<!-- 디폴트 이미지 → 실제 이미지로 정상 표시되는 화면 첨부 권장 -->

### Testing

1. 이미지가 있는 가게와 없는 가게 모두 테스트
2. 실제 이미지가 정상적으로 표시되는지 확인
3. 없는 경우 디폴트 이미지가 적용되는지 확인
4. 이미지 로딩 실패 상황에서도 UI가 깨지지 않도록 처리 확인

### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

### Additional Notes

- 이미지 존재 여부 판단 로직은 `이미지 URL 유효성 + 로딩 오류 대비` 조건으로 구성됨  
- 디폴트 이미지는 `public` 또는 `assets` 경로에서 관리됨
