### PR TITLE
fix: semantic-release 브랜치 설정 수정

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,13 @@
 {
-  "branches": ["develop", "next"],
+  "branches": [
+    {
+      "name": "main"
+    },
+    {
+      "name": "develop",
+      "prerelease": "beta"
+    }
+  ],
   "plugins": [
     [
       "@semantic-release/commit-analyzer",


### PR DESCRIPTION
### Description

semantic-release의 브랜치별 버전 태그 전략을 수정하여 main과 develop 브랜치에서 각각 다른 형식의 버전이 생성되도록 설정했습니다.

### Related Issues

-Closes #15 

### Changes Made

1. `.releaserc.json` 파일의 branches 설정 수정
   - `main` 브랜치: 일반 버전 형식 사용 (예: `1.0.0` -> `1.0.1`)
   - `develop` 브랜치: beta 태그 추가 (예: `1.0.0-beta` -> `1.0.1-beta`)
   - 불필요한 `next` 브랜치 설정 제거
2. 브랜치별 버전 태그 전략 명확화
   - `main` 브랜치에서는 정식 버전 번호만 사용
   - `develop` 브랜치에서는 버전 번호에 `-beta` 접미사 추가

### Testing

1. `main` 브랜치 버전 생성 테스트
   - 예상 결과: `1.0.0` -> `1.0.1` -> `1.0.2`
2. `develop` 브랜치 버전 생성 테스트
   - 예상 결과: `1.0.0-beta` -> `1.0.1-beta`

### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] semantic-release 설정이 올바르게 적용되는지 확인했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

### Additional Notes

이 PR이 머지되면 semantic-release가 브랜치별로 다른 버전 태그 전략을 적용하여 자동으로 버전을 관리하게 됩니다. 이를 통해 개발 버전과 프로덕션 버전을 명확하게 구분할 수 있습니다.