### PR TITLE
fix: 브랜치명 develop에서 dev로 수정

### DIFF
--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -1,10 +1,10 @@
-name: Develop Branch Semantic Release
+name: 🏷️ Frontend Semantic Release
 
 on:
   push:
     branches:
       - main
-      - develop
+      - dev
   workflow_dispatch: # GitHub Actions에서 수동 실행 가능하도록 추가
 
 jobs:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -4,7 +4,7 @@
       "name": "main"
     },
     {
-      "name": "develop",
+      "name": "dev",
       "prerelease": "beta"
     }
   ],


### PR DESCRIPTION
### Description

semantic-release의 브랜치별 버전 태그 전략을 수정하여 main과 dev 브랜치에서 각각 다른 형식의 버전이 생성되도록 설정했습니다.

### Related Issues

- Resolves #15

### Changes Made

1. `.releaserc.json` 파일의 branches 설정 수정
   - `main` 브랜치: 일반 버전 형식 사용 (예: `1.0.0` -> `1.0.1`)
   - `dev` 브랜치: beta 태그 추가 (예: `1.0.0-beta` -> `1.0.1-beta`)
   - 불필요한 `next` 브랜치 설정 제거
2. 브랜치별 버전 태그 전략 명확화
   - `main` 브랜치에서는 정식 버전 번호만 사용
   - `dev` 브랜치에서는 버전 번호에 `-beta` 접미사 추가
3. GitHub Actions workflow 수정
   - 브랜치명을 `develop`에서 `dev`로 수정하여 현재 프로젝트 구조에 맞게 조정


### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] semantic-release 설정이 올바르게 적용되는지 확인했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

### Additional Notes

이 PR이 머지되면 semantic-release가 브랜치별로 다른 버전 태그 전략을 적용하여 자동으로 버전을 관리하게 됩니다. 이를 통해 개발 버전과 프로덕션 버전을 명확하게 구분할 수 있습니다. 또한 GitHub Actions가 `dev` 브랜치에 대해 정상적으로 실행될 것입니다.