### PR TITLE
fix: @semantic-release/git 플러그인 제거

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -9,124 +9,102 @@
     }
   ],
   "plugins": [
-    [
-      "@semantic-release/commit-analyzer",
-      {
-        "preset": "conventionalcommits",
-        "releaseRules": [
-          { "type": "breaking", "release": "major" },
-          { "type": "no-release", "release": false },
-          { "type": "build", "release": false },
-          { "type": "chore", "release": false },
-          { "type": "content", "release": "patch" },
-          { "type": "docs", "release": "patch" },
-          { "type": "feat", "release": "minor" },
-          { "type": "fix", "release": "patch" },
-          { "type": "refactor", "release": "patch" },
-          { "type": "style", "release": "patch" },
-          { "type": "test", "release": false },
-          { "type": "deploy", "release": "patch" }
-        ],
-        "parserOpts": {
-          "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES"]
-        }
+    ["@semantic-release/commit-analyzer", {
+      "preset": "conventionalcommits",
+      "releaseRules": [
+        { "type": "breaking", "release": "major" },
+        { "type": "no-release", "release": false },
+        { "type": "build", "release": false },
+        { "type": "chore", "release": false },
+        { "type": "content", "release": "patch" },
+        { "type": "docs", "release": "patch" },
+        { "type": "feat", "release": "minor" },
+        { "type": "fix", "release": "patch" },
+        { "type": "refactor", "release": "patch" },
+        { "type": "style", "release": "patch" },
+        { "type": "test", "release": false },
+        { "type": "deploy", "release": "patch" }
+      ],
+      "parserOpts": {
+        "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES"]
       }
-    ],
-    [
-      "@semantic-release/release-notes-generator",
-      {
-        "preset": "conventionalcommits",
-        "presetConfig": {
-          "types": [
-            {
-              "type": "build",
-              "section": "⚙️ SYSTEM BUILD & EXTERNAL PACKAGES",
-              "hidden": true
-            },
-            {
-              "type": "chore",
-              "section": "📦 CHORES",
-              "hidden": true
-            },
-            {
-              "type": "content",
-              "section": "📝 CONTENT UPDATES",
-              "hidden": false
-            },
-            {
-              "type": "docs",
-              "section": "📚 DOCUMENTATION",
-              "hidden": false
-            },
-            {
-              "type": "feat",
-              "section": "🚀 NEW FEATURES",
-              "hidden": false
-            },
-            {
-              "type": "fix",
-              "section": "🐛 BUG FIXES",
-              "hidden": false
-            },
-            {
-              "type": "refactor",
-              "section": "♻️ REFACTORING",
-              "hidden": false
-            },
-            {
-              "type": "style",
-              "section": "🎨 STYLES",
-              "hidden": false
-            },
-            {
-              "type": "test",
-              "section": "✅ TESTING",
-              "hidden": true
-            },
-            {
-              "type": "deploy",
-              "section": "🚀 DEPLOYMENTS",
-              "hidden": false
-            }
-          ]
-        },
-        "parserOpts": {
-          "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES"]
-        },
-        "writerOpts": {
-          "commitsSort": ["subject", "scope"]
-        }
+    }],
+    ["@semantic-release/release-notes-generator", {
+      "preset": "conventionalcommits",
+      "presetConfig": {
+        "types": [
+          {
+            "type": "build",
+            "section": "⚙️ SYSTEM BUILD & EXTERNAL PACKAGES",
+            "hidden": true
+          },
+          {
+            "type": "chore",
+            "section": "📦 CHORES",
+            "hidden": true
+          },
+          {
+            "type": "content",
+            "section": "📝 CONTENT UPDATES",
+            "hidden": false
+          },
+          {
+            "type": "docs",
+            "section": "📚 DOCUMENTATION",
+            "hidden": false
+          },
+          {
+            "type": "feat",
+            "section": "🚀 NEW FEATURES",
+            "hidden": false
+          },
+          {
+            "type": "fix",
+            "section": "🐛 BUG FIXES",
+            "hidden": false
+          },
+          {
+            "type": "refactor",
+            "section": "♻️ REFACTORING",
+            "hidden": false
+          },
+          {
+            "type": "style",
+            "section": "🎨 STYLES",
+            "hidden": false
+          },
+          {
+            "type": "test",
+            "section": "✅ TESTING",
+            "hidden": true
+          },
+          {
+            "type": "deploy",
+            "section": "🚀 DEPLOYMENTS",
+            "hidden": false
+          }
+        ]
+      },
+      "parserOpts": {
+        "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES"]
+      },
+      "writerOpts": {
+        "commitsSort": ["subject", "scope"]
       }
-    ],
-    [
-      "@semantic-release/changelog",
-      {
-        "changelogFile": "CHANGELOG.md",
-        "changelogTitle": "# CHANGELOG"
-      }
-    ],
-    [
-      "@semantic-release/npm",
-      {
-        "pkgRoot": ".",
-        "tarball": "dist"
-      }
-    ],
-    [
-      "@semantic-release/github",
-      {
-        "successComment": false,
-        "failComment": false,
-        "failTitle": false,
-        "releasedLabels": false
-      }
-    ],
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["package.json", "package-lock.json", "CHANGELOG.md"],
-        "message": "chore: ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-      }
-    ]
+    }],
+    ["@semantic-release/changelog", {
+      "changelogFile": "CHANGELOG.md",
+      "changelogTitle": "# CHANGELOG"
+    }],
+    ["@semantic-release/npm", {
+      "pkgRoot": ".",
+      "tarball": "dist"
+    }],
+    ["@semantic-release/github", {
+      "successComment": false,
+      "failComment": false,
+      "failTitle": false,
+      "releasedLabels": false
+    }]
   ]
 }


### PR DESCRIPTION
### Description

semantic-release가 보호된 브랜치에서도 정상적으로 작동하도록 설정을 수정했습니다. `@semantic-release/git` 플러그인을 제거하여 보호된 브랜치에 직접적인 커밋 없이 태그와 GitHub Release만 생성하도록 변경했습니다.

### Related Issues

- Resolves #15

### Changes Made

1. `.releaserc.json` 파일 수정
   - `@semantic-release/git` 플러그인 제거
   - 보호된 브랜치에 직접 커밋하지 않도록 설정
   - 기존의 커밋 분석, 릴리즈 노트, changelog, npm, github 플러그인은 유지

2. 브랜치별 버전 태그 전략 설정
   - `main` 브랜치: 정식 버전 (예: `1.0.0`)
   - `dev` 브랜치: beta 버전 (예: `1.0.0-beta`)

3. GitHub Actions workflow 설정 최적화
   - 기본 `GITHUB_TOKEN` 사용
   - 필요한 권한들(contents, issues, pull-requests) 설정

### Testing

1. `dev` 브랜치 버전 생성 테스트
   - PR 머지 시 GitHub Actions 실행
   - beta 태그가 포함된 버전 생성 (예: `1.0.0-beta`)
   - GitHub Release 생성 확인

2. Protected 브랜치 정책 준수 확인
   - 직접적인 커밋 없이 태그와 Release만 생성
   - 브랜치 보호 설정과 충돌하지 않음

### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] semantic-release 설정이 올바르게 적용되는지 확인했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

### Additional Notes

이 PR이 머지되면 semantic-release가 보호된 브랜치 정책을 준수하면서도 자동으로 버전을 관리할 수 있게 됩니다. 직접적인 커밋 대신 태그와 GitHub Release만 생성하여 버전 관리의 안정성을 높였습니다.