### PR TITLE
feat: 환경 변수에서 API URL을 로드하도록 수정

### DIFF
--- a/src/api/apiClient.js
+++ b/src/api/apiClient.js
@@ -1,5 +1,6 @@
 import axios from 'axios'
 import { handleErrorResponse, ERROR_MESSAGES } from '../utils/apiMessages'
+import { API_BASE_URL, API_DIRECT_URL } from '../config/apiConfig'
 
 // API 접두사 설정
 const API_PREFIX = '/api'
@@ -32,13 +33,13 @@ apiClient.interceptors.request.use(
       // URL 통합 처리
       if (config.url.startsWith('/v1/')) {
         // /v1/로 시작하는 경우 - /api를 추가하고 도메인 추가
-        config.url = `${process.env.NODE_ENV === 'development' ? 'https://dxa66rf338pjr.cloudfront.net' : 'https://dxa66rf338pjr.cloudfront.net'}/api${config.url}`
+        config.url = `${API_DIRECT_URL}/api${config.url}`
       } else if (config.url.startsWith('/api/')) {
         // /api/로 시작하는 경우 - 그대로 도메인만 추가
-        config.url = `${process.env.NODE_ENV === 'development' ? 'https://dxa66rf338pjr.cloudfront.net' : 'https://dxa66rf338pjr.cloudfront.net'}${config.url}`
+        config.url = `${API_DIRECT_URL}${config.url}`
       } else {
         // 그 외 - 모든 API 엔드포인트는 /api/v1/로 시작하도록 설정
-        config.url = `${process.env.NODE_ENV === 'development' ? 'https://dxa66rf338pjr.cloudfront.net' : 'https://dxa66rf338pjr.cloudfront.net'}/api/v1${config.url.startsWith('/') ? '' : '/'}${config.url}`
+        config.url = `${API_DIRECT_URL}/api/v1${config.url.startsWith('/') ? '' : '/'}${config.url}`
       }
     }
 

--- a/src/api/uploadApi.js
+++ b/src/api/uploadApi.js
@@ -1,5 +1,4 @@
-// 기본 API URL
-const API_BASE_URL = 'https://dxa66rf338pjr.cloudfront.net'
+import { API_BASE_URL, API_DIRECT_URL } from '../config/apiConfig'
 
 /**
  * 이미지를 업로드하고 URL을 반환합니다.
@@ -20,11 +19,11 @@ export const uploadImage = async (imageFile, uploadPath) => {
     // 토큰 가져오기
     const accessToken = localStorage.getItem('accessToken');
 
-    console.log('이미지 업로드 시작:', `${API_BASE_URL}/api/v1${uploadPath}`);
+    console.log('이미지 업로드 시작:', `${API_DIRECT_URL}/api/v1${uploadPath}`);
     console.log('업로드 이미지 정보:', imageFile.name, imageFile.type, imageFile.size);
 
     // fetch를 사용한 이미지 업로드
-    const response = await fetch(`${API_BASE_URL}/api/v1${uploadPath}`, {
+    const response = await fetch(`${API_DIRECT_URL}/api/v1${uploadPath}`, {
       method: 'POST',
       headers: {
         Authorization: accessToken ? `Bearer ${accessToken}` : '',

--- a/src/config/apiConfig.js
+++ b/src/config/apiConfig.js
@@ -1,13 +1,11 @@
 // API 설정 파일
 const isDevelopment = process.env.NODE_ENV === 'development'
 
-const API_BASE_URL = isDevelopment 
-  ? 'https://dxa66rf338pjr.cloudfront.net/api/v1'
-  : 'https://dxa66rf338pjr.cloudfront.net/api/v1'
+// 환경변수에서 API URL 가져오기 (없으면 기본값 사용)
+const API_URL = import.meta.env.VITE_API_URL || 'https://dxa66rf338pjr.cloudfront.net'
 
-const API_DIRECT_URL = isDevelopment
-  ? 'https://dxa66rf338pjr.cloudfront.net'
-  : 'https://dxa66rf338pjr.cloudfront.net'
+const API_BASE_URL = `${API_URL}/api/v1`
+const API_DIRECT_URL = API_URL
 
 // API 엔드포인트
 const API_ENDPOINTS = {

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 
@@ -6,41 +6,49 @@ import path from 'path'
 const mode =
   process.env.NODE_ENV === 'production' ? 'production' : 'development'
 
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    port: 3000,
-    proxy: {
-      '/api': {
-        target: 'https://dxa66rf338pjr.cloudfront.net',
-        changeOrigin: true,
-        secure: true,
-        ws: true,
-        // rewrite: (path) => path.replace(/^\/api/, ''),
-        configure: (proxy, _options) => {
-          proxy.on('error', (err, _req, _res) => {
-            console.log('프록시 에러:', err)
-          })
-          proxy.on('proxyReq', (proxyReq, req, _res) => {
-            console.log('프록시 요청:', req.method, req.url)
-          })
-          proxy.on('proxyRes', (proxyRes, req, _res) => {
-            console.log('프록시 응답:', proxyRes.statusCode, req.url)
-          })
+export default defineConfig(({ mode }) => {
+  // 환경 변수 로드
+  const env = loadEnv(mode, process.cwd())
+  
+  // 기본 API URL 설정 (환경변수가 없으면 클라우드프론트 URL 사용)
+  const apiUrl = env.VITE_API_URL || 'https://dxa66rf338pjr.cloudfront.net'
+  
+  return {
+    plugins: [react()],
+    server: {
+      port: 3000,
+      proxy: {
+        '/api': {
+          target: apiUrl,
+          changeOrigin: true,
+          secure: true,
+          ws: true,
+          // rewrite: (path) => path.replace(/^\/api/, ''),
+          configure: (proxy, _options) => {
+            proxy.on('error', (err, _req, _res) => {
+              console.log('프록시 에러:', err)
+            })
+            proxy.on('proxyReq', (proxyReq, req, _res) => {
+              console.log('프록시 요청:', req.method, req.url)
+            })
+            proxy.on('proxyRes', (proxyRes, req, _res) => {
+              console.log('프록시 응답:', proxyRes.statusCode, req.url)
+            })
+          },
         },
       },
     },
-  },
-  build: {
-    outDir: `dist/${mode}`,
-    emptyOutDir: true,
-    rollupOptions: {
-      input: path.resolve(__dirname, 'index.html'),
-      output: {
-        entryFileNames: 'assets/[name].[hash].js',
-        chunkFileNames: 'assets/[name].[hash].js',
-        assetFileNames: 'assets/[name].[hash].[ext]',
+    build: {
+      outDir: `dist/${mode}`,
+      emptyOutDir: true,
+      rollupOptions: {
+        input: path.resolve(__dirname, 'index.html'),
+        output: {
+          entryFileNames: 'assets/[name].[hash].js',
+          chunkFileNames: 'assets/[name].[hash].js',
+          assetFileNames: 'assets/[name].[hash].[ext]',
+        },
       },
     },
-  },
+  }
 })


### PR DESCRIPTION
# 환경변수 기반 API URL 설정 기능 추가

## 변경 내용
- 개발환경(dev)과 운영환경(main)의 API 요청 URL을 구분하여 관리할 수 있도록 환경변수 기반 설정 추가
- `.env` 파일을 사용한 로컬 개발 환경 설정 지원
- GitHub Actions에서 환경별 시크릿으로 환경변수 주입 가능하도록 구성

## 주요 수정 사항
1. `import.meta.env.VITE_API_URL`을 통한 환경변수 접근 구현
2. 환경변수가 없을 경우 기본값으로 클라우드프론트 URL 사용
3. 하드코딩된 URL을 환경변수 기반 URL로 대체
4. Vite 설정에 환경변수 로드 기능 추가

## 테스트 방법
1. 로컬에서 `.env` 파일에 `VITE_API_URL` 설정
2. 개발 환경에서는 클라우드프론트로, 운영 환경에서는 luckeat.net으로 요청 확인

## 주의사항
- `.env` 파일은 `.gitignore`에 추가하여 저장소에 커밋되지 않도록 함