### PR TITLE
chore: 환경별 API URL 분리 설정 추가

### DIFF
--- a/.github/workflows/s3-deploy.yml
+++ b/.github/workflows/s3-deploy.yml
@@ -18,9 +18,11 @@ jobs:
           if [[ $GITHUB_REF == 'refs/heads/main' ]]; then
             echo "ENVIRONMENT=production" >> $GITHUB_ENV
             echo "CLOUDFRONT_ID=${{ secrets.CLOUDFRONT_DISTRIBUTION_ID_PROD }}" >> $GITHUB_ENV
+            echo "VITE_API_URL=${{ secrets.VITE_API_URL_PROD }}" >> $GITHUB_ENV
           else
             echo "ENVIRONMENT=development" >> $GITHUB_ENV
             echo "CLOUDFRONT_ID=${{ secrets.CLOUDFRONT_DISTRIBUTION_ID_DEV }}" >> $GITHUB_ENV
+            echo "VITE_API_URL=${{ secrets.VITE_API_URL_DEV }}" >> $GITHUB_ENV
           fi
           echo "Deploying to $ENVIRONMENT environment"
 
@@ -41,6 +43,7 @@ jobs:
           NODE_ENV: ${{ env.ENVIRONMENT }}
           VITE_KAKAO_API_KEY: ${{ secrets.VITE_KAKAO_API_KEY }}
           VITE_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          VITE_API_URL: ${{ env.VITE_API_URL }}
 
       - name: List build directory
         run: |


### PR DESCRIPTION
### Description

GitHub Actions 워크플로우에서 환경별(개발/프로덕션) API URL을 분리하여 설정할 수 있도록 수정했습니다. 이를 통해 각 환경에 맞는 API 엔드포인트를 사용할 수 있게 됩니다.

### Related Issues

- Resolves #121

### Changes Made

1. GitHub Actions 워크플로우 파일에 환경별 API URL 설정 추가
   - 프로덕션 환경: `VITE_API_URL_PROD` 시크릿 사용
   - 개발 환경: `VITE_API_URL_DEV` 시크릿 사용
2. 빌드 단계에 `VITE_API_URL` 환경변수 전달 로직 추가

### Testing

1. GitHub Actions 워크플로우 파일 문법 검증

### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] GitHub Actions 워크플로우 문법이 올바른지 확인했습니다.
- [x] 환경변수 설정이 정상적으로 동작하는지 확인했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.

### Additional Notes

- GitHub 저장소의 Settings > Secrets and variables > Actions에서 다음 시크릿들을 추가해야 합니다:
  - `VITE_API_URL_PROD`: 프로덕션 환경의 API URL
  - `VITE_API_URL_DEV`: 개발 환경의 API URL
- 프로젝트에서는 `import.meta.env.VITE_API_URL`을 통해 환경변수에 접근할 수 있습니다.