### PR TITLE
feat: 가게 정보 수정 페이지에서 설명 및 연락처 처리 로직 개선

### DIFF
--- a/src/pages/EditStorePage.jsx
+++ b/src/pages/EditStorePage.jsx
@@ -133,6 +133,9 @@ function EditStorePage() {
         storeName: store.storeName,
         address: store.address,
         businessNumber: store.businessNumber,
+        // 설명이 비어있으면 공백 문자 하나를 보냅니다. 서버의 유효성 검사를 통과하기 위함
+        description: formData.description === '' ? ' ' : formData.description,
+        contactNumber: formData.contactNumber || store.contactNumber || '',
         reviewSummary: store.reviewSummary || '',
         avgRating: store.avgRating || 0,
         avgRatingGoogle: store.avgRatingGoogle || 0,
@@ -346,7 +349,9 @@ function EditStorePage() {
                   </label>
                   <div className="bg-gray-50 p-4 border rounded-lg text-gray-700">
                     {store?.reviewSummary ? (
-                      <p className="text-sm leading-relaxed">{store.reviewSummary}</p>
+                      <p className="text-sm leading-relaxed">
+                        {store.reviewSummary}
+                      </p>
                     ) : (
                       <p className="text-sm text-gray-500">
                         리뷰 요약 정보가 없습니다.
@@ -382,7 +387,6 @@ function EditStorePage() {
                     className="w-full p-3 border rounded-lg focus:ring-2 focus:ring-[#F7B32B] focus:border-transparent"
                     rows="4"
                     placeholder="가게 소개를 입력해주세요"
-                    required
                   />
                 </div>
 
@@ -398,7 +402,6 @@ function EditStorePage() {
                     onChange={handleInputChange}
                     className="w-full p-3 border rounded-lg focus:ring-2 focus:ring-[#F7B32B] focus:border-transparent"
                     placeholder="연락처를 입력해주세요"
-                    required
                   />
                 </div>
               </div>


### PR DESCRIPTION
### Description

- 빈 문자열일 경우 서버 유효성 검사를 통과하기 위해 공백 문자 하나를 전송하도록 수정
- 폼 데이터에 연락처가 없을 경우 기존 가게 정보의 연락처를 사용
- 둘 다 없는 경우 빈 문자열로 처리
- 설명과 연락처 입력 필드에서 required 속성 제거
- 리뷰 요약 정보 표시 부분의 코드 포맷팅 개선


