### PR TITLE
가게 이름과 주소를 각각 최대 20자로 제한

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -551,11 +551,15 @@ function HomePage() {
                     />
                   </div>
                   <div className="flex-1 ml-3">
-                    <h3 className="font-bold">
-                      {store.storeName || store.name || '이름 없음'}
+                    <h3 className="font-bold truncate" title={store.storeName || store.name || '이름 없음'}>
+                      {(store.storeName || store.name || '이름 없음').length > 20 
+                        ? (store.storeName || store.name || '이름 없음').substring(0, 20) + '...'
+                        : (store.storeName || store.name || '이름 없음')}
                     </h3>
-                    <p className="text-sm text-gray-500">
-                      {store.address || '주소 정보 없음'}
+                    <p className="text-sm text-gray-500 truncate" title={store.address || '주소 정보 없음'}>
+                      {(store.address || '주소 정보 없음').length > 20
+                        ? (store.address || '주소 정보 없음').substring(0, 20) + '...'
+                        : (store.address || '주소 정보 없음')}
                     </p>
                     <div className="flex items-center">
                       <div className="flex items-center text-sm text-yellow-500 mr-2">

--- a/src/pages/MapPage.jsx
+++ b/src/pages/MapPage.jsx
@@ -520,8 +520,10 @@ function MapPage() {
                     />
                   </div>
                   <div className="flex-1">
-                    <h4 className="font-bold text-sm">
-                      {store.storeName || store.name}
+                    <h4 className="font-bold text-sm truncate" title={store.storeName || store.name}>
+                      {(store.storeName || store.name).length > 20
+                        ? (store.storeName || store.name).substring(0, 20) + '...'
+                        : (store.storeName || store.name)}
                     </h4>
                     <div className="flex items-center flex-wrap gap-1 mt-1">
                       {/* 할인 표시 개선 */}
@@ -540,8 +542,10 @@ function MapPage() {
                         </span>
                       )}
                     </div>
-                    <p className="text-xs text-gray-500 mt-1 truncate">
-                      {simplifyAddress(store.address || '주소 정보 없음')}
+                    <p className="text-xs text-gray-500 mt-1 truncate" title={store.address || '주소 정보 없음'}>
+                      {simplifyAddress(store.address || '주소 정보 없음').length > 20
+                        ? simplifyAddress(store.address || '주소 정보 없음').substring(0, 20) + '...'
+                        : simplifyAddress(store.address || '주소 정보 없음')}
                     </p>
                     {/* 별점 표시 */}
                     <div className="flex items-center mt-1">


### PR DESCRIPTION
### Description

가게 이름과 주소가 너무 길 경우 레이아웃이 깨지는 문제를 방지하기 위해  
**가게 이름과 주소를 각각 최대 20자까지만 표시하고 이후는 `...` 으로 생략** 처리함  
메인페이지와 지도페이지의 가게 목록 모두 동일한 기준을 적용함

### Related Issues

- Resolves #138

### Changes Made

1. 메인페이지 가게 목록에서 가게 이름과 주소를 각각 최대 20자로 제한
2. 지도페이지 가게 목록에서도 동일한 방식으로 처리
3. `text-overflow: ellipsis`, `overflow: hidden`, `white-space: nowrap` CSS 적용
4. 반응형 레이아웃에서도 텍스트 잘림 현상 없이 자연스럽게 보이도록 조정

### Screenshots or Video

<!-- 텍스트 잘리기 전/후 UI 캡처 첨부 권장 -->

### Testing

1. 20자 이상의 가게 이름 및 주소가 '…'으로 생략되어 표시되는지 확인
2. 텍스트 생략으로 인한 UI 깨짐이 없는지 확인
3. 모바일 및 데스크탑 환경에서 모두 반응형 UI 정상 동작 확인
4. 툴팁 또는 전체 주소 표시 여부는 추후 논의로 반영 가능

### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

### Additional Notes

- 텍스트 길이 제한은 추후 디자인 요구사항에 따라 조정 가능  
- 툴팁을 통한 전체 텍스트 노출 여부는 UX 측면에서 추가 검토 필요
