### PR TITLE
[FE] 모든 페이지 비로그인 접근 허용 및 보호로직 주석 처리

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -51,25 +51,13 @@ function AuthWrapper({ children }) {
   const location = useLocation()
 
   useEffect(() => {
-    // 현재 경로가 인증이 필요하지 않은 경로인지 확인
-    const publicPaths = ['/login', '/signup', '/', '/home', '/map']
-    const isPublicPath = publicPaths.includes(location.pathname)
-
-    // 인증이 필요한 경로에서만 토큰 유효성 검사
-    if (!isPublicPath) {
-      const isValid = checkCurrentAuthStatus()
-
-      // 유효하지 않은 토큰을 가진 경우 로그인 페이지로 리다이렉션
-      if (!isValid && location.pathname !== '/login') {
-        navigate('/login', {
-          replace: true,
-          state: {
-            from: location.pathname,
-            message: '로그인이 필요하거나 세션이 만료되었습니다.',
-          },
-        })
-      }
+    // 모든 사용자가 모든 페이지에 접근할 수 있도록 변경
+    // 단, 토큰이 있는 경우 토큰 유효성 검사는 그대로 수행 (로그인 상태 유지용)
+    if (localStorage.getItem('accessToken')) {
+      checkCurrentAuthStatus()
     }
+    // 주의: 이 변경으로 모든 사용자가 모든 페이지에 접근할 수 있게 됩니다.
+    // 필요한 경우 원래 코드로 되돌리세요.
   }, [location.pathname, checkCurrentAuthStatus, navigate, location])
 
   return children
@@ -89,7 +77,10 @@ function AppRoutes() {
         <Route path="/store/:id" element={<StoreDetailPage />} />
         <Route path="/reviews" element={<ReviewManagementPage />} />
         <Route path="/edit-profile" element={<EditProfilePage />} />
-        <Route path="/store/:storeId/products" element={<ProductManagementPage />} />
+        <Route
+          path="/store/:storeId/products"
+          element={<ProductManagementPage />}
+        />
         <Route path="/edit-store" element={<EditStorePage />} />
       </Routes>
     </AuthWrapper>

--- a/src/pages/BusinessPage.jsx
+++ b/src/pages/BusinessPage.jsx
@@ -9,7 +9,7 @@ import StoreCard from '../components/store/StoreCard'
 
 function BusinessPage() {
   const navigate = useNavigate()
-  const { user, logout } = useAuth()
+  const { user, logout, isLoggedIn } = useAuth()
   const [userData, setUserData] = useState(null)
   const [storeData, setStoreData] = useState(null)
   const [loading, setLoading] = useState(true)
@@ -17,22 +17,54 @@ function BusinessPage() {
 
   // 사용자 정보와 가게 정보 가져오기
   useEffect(() => {
+    // 기존 코드 주석 처리
+    // const fetchData = async () => {
+    //   try {
+    //     setLoading(true)
+
+    //     // 사용자 정보 가져오기
+    //     const userResponse = await getUserInfo()
+    //     if (userResponse.success) {
+    //       setUserData(userResponse.data)
+    //     }
+
+    //     // 가게 정보 가져오기
+    //     const storeResponse = await getMyStore()
+    //     if (storeResponse.success) {
+    //       setStoreData(storeResponse.data)
+    //       console.log('가게 정보:', storeResponse.data)
+    //       console.log('가게 ID 속성:', Object.keys(storeResponse.data))
+    //     }
+    //   } catch (error) {
+    //     console.error('데이터 로딩 중 오류:', error)
+    //   } finally {
+    //     setLoading(false)
+    //   }
+    // }
+
+    // if (user) {
+    //   fetchData()
+    // }
+    
+    // 새로운 코드: 로그인 상태 확인 후 데이터 가져오기
     const fetchData = async () => {
       try {
         setLoading(true)
 
-        // 사용자 정보 가져오기
-        const userResponse = await getUserInfo()
-        if (userResponse.success) {
-          setUserData(userResponse.data)
-        }
+        if (isLoggedIn && user) {
+          // 사용자 정보 가져오기
+          const userResponse = await getUserInfo()
+          if (userResponse.success) {
+            setUserData(userResponse.data)
+          }
 
-        // 가게 정보 가져오기
-        const storeResponse = await getMyStore()
-        if (storeResponse.success) {
-          setStoreData(storeResponse.data)
-          console.log('가게 정보:', storeResponse.data)
-          console.log('가게 ID 속성:', Object.keys(storeResponse.data))
+          // 가게 정보 가져오기
+          const storeResponse = await getMyStore()
+          if (storeResponse.success) {
+            setStoreData(storeResponse.data)
+            console.log('가게 정보:', storeResponse.data)
+            console.log('가게 ID 속성:', Object.keys(storeResponse.data))
+          }
         }
       } catch (error) {
         console.error('데이터 로딩 중 오류:', error)
@@ -41,10 +73,12 @@ function BusinessPage() {
       }
     }
 
-    if (user) {
-      fetchData()
+    fetchData()
+    // 로그인하지 않은 경우 로딩 상태 해제
+    if (!isLoggedIn) {
+      setLoading(false)
     }
-  }, [user])
+  }, [user, isLoggedIn])
 
   const handleLogout = async () => {
     try {
@@ -76,77 +110,109 @@ function BusinessPage() {
           </div>
         ) : (
           <>
-            {/* 사업자 페이지 제목 */}
-            <div className="p-6 text-center">
-              <h1 className="text-3xl font-bold text-gray-800">
-                사업자 페이지
-              </h1>
-            </div>
-            
-            {/* 가게 정보 카드 */}
-            {storeData ? (
-              <div className="px-4 mb-6">
-                <h2 className="text-xl font-bold text-gray-700 mb-3">
-                  내 가게 정보
-                </h2>
-                <StoreCard store={storeData} />
-              </div>
-            ) : (
-              <div className="px-4 py-6 mb-6 bg-gray-100 rounded-lg mx-4 text-center">
-                <p className="text-gray-600 mb-3">
-                  등록된 가게 정보가 없습니다.
-                </p>
-                <button
-                  className="py-2 px-4 bg-[#F7B32B] hover:bg-[#E09D18] text-white font-bold rounded transition-colors"
-                  onClick={() => navigate('/register-store')}
-                >
-                  가게 등록하기
-                </button>
-              </div>
-            )}
-            
-            <div className="mt-6">
-              {/* 메뉴 목록 */}
-              <div className="p-4 space-y-4">
-                <div className="border-b pb-2">
-                  <button
-                    className="w-full text-left font-bold text-gray-700 flex justify-between items-center"
-                    onClick={() => storeData && navigate(`/store/${storeData.id}/products`)}
-                    disabled={!storeData}
-                  >
-                    <span>상품 정보</span>
-                    <span className="text-gray-400">→</span>
-                  </button>
+            {isLoggedIn ? (
+              // 로그인 상태일 때 기존 UI 표시
+              <>
+                {/* 사업자 페이지 제목 */}
+                <div className="p-6 text-center">
+                  <h1 className="text-3xl font-bold text-gray-800">
+                    사업자 페이지
+                  </h1>
                 </div>
+                
+                {/* 가게 정보 카드 */}
+                {storeData ? (
+                  <div className="px-4 mb-6">
+                    <h2 className="text-xl font-bold text-gray-700 mb-3">
+                      내 가게 정보
+                    </h2>
+                    <StoreCard store={storeData} />
+                  </div>
+                ) : (
+                  <div className="px-4 py-6 mb-6 bg-gray-100 rounded-lg mx-4 text-center">
+                    <p className="text-gray-600 mb-3">
+                      등록된 가게 정보가 없습니다.
+                    </p>
+                    <button
+                      className="py-2 px-4 bg-[#F7B32B] hover:bg-[#E09D18] text-white font-bold rounded transition-colors"
+                      onClick={() => navigate('/register-store')}
+                    >
+                      가게 등록하기
+                    </button>
+                  </div>
+                )}
+                
+                <div className="mt-6">
+                  {/* 메뉴 목록 */}
+                  <div className="p-4 space-y-4">
+                    <div className="border-b pb-2">
+                      <button
+                        className="w-full text-left font-bold text-gray-700 flex justify-between items-center"
+                        onClick={() => storeData && navigate(`/store/${storeData.id}/products`)}
+                        disabled={!storeData}
+                      >
+                        <span>상품 정보</span>
+                        <span className="text-gray-400">→</span>
+                      </button>
+                    </div>
 
-                <div className="border-b pb-2">
-                  <button
-                    className="w-full text-left font-bold text-gray-700 flex justify-between items-center"
-                    onClick={() => navigate('/edit-store')}
-                  >
-                    <span>가게 정보</span>
-                    <span className="text-gray-400">→</span>
-                  </button>
-                </div>
+                    <div className="border-b pb-2">
+                      <button
+                        className="w-full text-left font-bold text-gray-700 flex justify-between items-center"
+                        onClick={() => navigate('/edit-store')}
+                      >
+                        <span>가게 정보</span>
+                        <span className="text-gray-400">→</span>
+                      </button>
+                    </div>
 
-                <div className="border-b pb-2">
-                  <button
-                    className="w-full text-left font-bold text-gray-700 flex justify-between items-center"
-                    onClick={() => setShowLogoutModal(true)}
-                  >
-                    <span>로그아웃</span>
-                    <span className="text-gray-400">→</span>
-                  </button>
-                </div>
+                    <div className="border-b pb-2">
+                      <button
+                        className="w-full text-left font-bold text-gray-700 flex justify-between items-center"
+                        onClick={() => setShowLogoutModal(true)}
+                      >
+                        <span>로그아웃</span>
+                        <span className="text-gray-400">→</span>
+                      </button>
+                    </div>
 
-                <div className="border-b pb-2">
-                  <div className="flex justify-between items-center">
-                    <span className="text-gray-500 font-bold">고객 문의</span>
-                    <span className="text-gray-400">luckeat@example.com</span>
+                    <div className="border-b pb-2">
+                      <div className="flex justify-between items-center">
+                        <span className="text-gray-500 font-bold">고객 문의</span>
+                        <span className="text-gray-400">luckeat@example.com</span>
+                      </div>
+                    </div>
                   </div>
                 </div>
+              </>
+            ) : (
+              // 비로그인 상태일 때 표시할 UI
+              <div className="p-8 flex flex-col items-center justify-center space-y-6">
+                <div className="text-center">
+                  <h3 className="text-xl font-bold mb-2">사업자 로그인이 필요합니다</h3>
+                  <p className="text-gray-500 mb-6">
+                    사업자 페이지를 이용하려면 로그인이 필요합니다.
+                    <br />로그인하고 가게를 관리해보세요!
+                  </p>
+                  <button
+                    className="py-3 px-6 bg-[#F7B32B] hover:bg-[#E09D18] text-white font-bold rounded-lg transition-colors"
+                    onClick={() => navigate('/login')}
+                  >
+                    로그인하러 가기
+                  </button>
+                </div>
+                
+                <div className="mt-8 w-full border-t pt-4 text-center">
+                  <p className="text-gray-500 mb-2">아직 계정이 없으신가요?</p>
+                  <button
+                    className="text-[#F7B32B] font-medium"
+                    onClick={() => navigate('/signup')}
+                  >
+                    회원가입하기
+                  </button>
+                </div>
               </div>
-            </div>
+            )}
           </>
         )}
 

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -9,7 +9,7 @@ import bakerDefaultImage from '../assets/images/제빵사디폴트이미지.png'
 
 function MyPage() {
   const navigate = useNavigate()
-  const { user, logout } = useAuth()
+  const { user, logout, isLoggedIn } = useAuth()
   const [userData, setUserData] = useState(null)
   const [reviews, setReviews] = useState([])
   const [loading, setLoading] = useState(true)
@@ -17,20 +17,51 @@ function MyPage() {
 
   // 사용자 정보와 리뷰 목록 가져오기
   useEffect(() => {
+    // 로그인한 경우에만 데이터를 가져옵니다
+    // 기존 코드 주석 처리
+    // const fetchUserData = async () => {
+    //   try {
+    //     setLoading(true)
+
+    //     // 사용자 정보 가져오기
+    //     const userResponse = await getUserInfo()
+    //     if (userResponse.success) {
+    //       setUserData(userResponse.data)
+    //     }
+
+    //     // 사용자 리뷰 가져오기
+    //     const reviewsResponse = await getMyReviews()
+    //     if (reviewsResponse && reviewsResponse.data) {
+    //       setReviews(reviewsResponse.data.reviews || [])
+    //     }
+    //   } catch (error) {
+    //     console.error('사용자 데이터 로딩 중 오류:', error)
+    //   } finally {
+    //     setLoading(false)
+    //   }
+    // }
+
+    // if (user) {
+    //   fetchUserData()
+    // }
+    
+    // 새로운 코드: 로그인 상태 확인 후 데이터 가져오기
     const fetchUserData = async () => {
       try {
         setLoading(true)
 
-        // 사용자 정보 가져오기
-        const userResponse = await getUserInfo()
-        if (userResponse.success) {
-          setUserData(userResponse.data)
-        }
+        if (isLoggedIn && user) {
+          // 사용자 정보 가져오기
+          const userResponse = await getUserInfo()
+          if (userResponse.success) {
+            setUserData(userResponse.data)
+          }
 
-        // 사용자 리뷰 가져오기
-        const reviewsResponse = await getMyReviews()
-        if (reviewsResponse && reviewsResponse.data) {
-          setReviews(reviewsResponse.data.reviews || [])
+          // 사용자 리뷰 가져오기
+          const reviewsResponse = await getMyReviews()
+          if (reviewsResponse && reviewsResponse.data) {
+            setReviews(reviewsResponse.data.reviews || [])
+          }
         }
       } catch (error) {
         console.error('사용자 데이터 로딩 중 오류:', error)
@@ -39,10 +70,12 @@ function MyPage() {
       }
     }
 
-    if (user) {
-      fetchUserData()
+    fetchUserData()
+    // 로그인하지 않은 경우 로딩 상태 해제
+    if (!isLoggedIn) {
+      setLoading(false)
     }
-  }, [user])
+  }, [user, isLoggedIn])
 
   const handleLogout = async () => {
     try {
@@ -74,80 +107,122 @@ function MyPage() {
           </div>
         ) : (
           <>
-            {/* 사용자 정보 */}
-            <div className="p-4 border-b border-gray-200">
-              <div className="flex items-center">
-                <div className="w-16 h-16 bg-gray-200 rounded-full flex items-center justify-center overflow-hidden">
+            {isLoggedIn ? (
+              // 로그인 상태일 때 기존 UI 표시
+              <>
+                {/* 사용자 정보 */}
+                <div className="p-4 border-b border-gray-200">
+                  <div className="flex items-center">
+                    <div className="w-16 h-16 bg-gray-200 rounded-full flex items-center justify-center overflow-hidden">
+                      <img
+                        src={bakerDefaultImage}
+                        alt="프로필"
+                        className="w-full h-full object-cover"
+                      />
+                    </div>
+                    <div className="ml-4">
+                      <h3 className="text-lg font-bold">
+                        {displayUser.nickname || '사용자'}님, 반갑수다~
+                      </h3>
+                      <p className="text-sm text-gray-500">
+                        {displayUser.email || '이메일 정보가 없습니다'}
+                      </p>
+                      <div className="flex items-center mt-1">
+                        <span className="text-[#F7B32B] font-bold">
+                          {reviews.length}
+                        </span>
+                        <span className="ml-1 text-sm text-gray-500">
+                          개의 리뷰
+                        </span>
+                      </div>
+                      {displayUser.createdAt && (
+                        <p className="text-xs text-gray-400 mt-1">
+                          가입일:{' '}
+                          {new Date(displayUser.createdAt).toLocaleDateString()}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                </div>
+
+                {/* 메뉴 목록 */}
+                <div className="p-4 space-y-4">
+                  <div className="border-b pb-2">
+                    <button
+                      className="w-full text-left font-bold text-gray-700 flex justify-between items-center"
+                      onClick={() => navigate('/reviews')}
+                    >
+                      <span>리뷰 관리</span>
+                      <span className="text-gray-400">→</span>
+                    </button>
+                  </div>
+
+                  <div className="border-b pb-2">
+                    <button
+                      className="w-full text-left font-bold text-gray-700 flex justify-between items-center"
+                      onClick={() => navigate('/edit-profile')}
+                    >
+                      <span>회원 정보 수정</span>
+                      <span className="text-gray-400">→</span>
+                    </button>
+                  </div>
+
+                  <div className="border-b pb-2">
+                    <button
+                      className="w-full text-left font-bold text-gray-700 flex justify-between items-center"
+                      onClick={() => setShowLogoutModal(true)}
+                    >
+                      <span>로그아웃</span>
+                      <span className="text-gray-400">→</span>
+                    </button>
+                  </div>
+
+                  <div className="border-b pb-2">
+                    <div className="flex justify-between items-center">
+                      <span className="text-gray-500">고객 문의</span>
+                      <span className="text-gray-400">luckeat@example.com</span>
+                    </div>
+                  </div>
+                </div>
+              </>
+            ) : (
+              // 비로그인 상태일 때 표시할 UI
+              <div className="p-8 flex flex-col items-center justify-center space-y-6">
+                <div className="w-24 h-24 bg-gray-200 rounded-full flex items-center justify-center overflow-hidden">
                   <img
                     src={bakerDefaultImage}
                     alt="프로필"
                     className="w-full h-full object-cover"
                   />
                 </div>
-                <div className="ml-4">
-                  <h3 className="text-lg font-bold">
-                    {displayUser.nickname || '사용자'}님, 반갑수다~
+                <div className="text-center">
+                  <h3 className="text-xl font-bold mb-2">
+                    로그인이 필요합니다
                   </h3>
-                  <p className="text-sm text-gray-500">
-                    {displayUser.email || '이메일 정보가 없습니다'}
+                  <p className="text-gray-500 mb-6">
+                    마이페이지를 이용하려면 로그인이 필요합니다.
+                    <br />
+                    로그인하고 제빵사의 다양한 기능을 사용해보세요!
                   </p>
-                  <div className="flex items-center mt-1">
-                    <span className="text-[#F7B32B] font-bold">
-                      {reviews.length}
-                    </span>
-                    <span className="ml-1 text-sm text-gray-500">
-                      개의 리뷰
-                    </span>
-                  </div>
-                  {displayUser.createdAt && (
-                    <p className="text-xs text-gray-400 mt-1">
-                      가입일:{' '}
-                      {new Date(displayUser.createdAt).toLocaleDateString()}
-                    </p>
-                  )}
+                  <button
+                    className="py-3 px-6 bg-[#F7B32B] hover:bg-[#E09D18] text-white font-bold rounded-lg transition-colors"
+                    onClick={() => navigate('/login')}
+                  >
+                    로그인하러 가기
+                  </button>
+                </div>
+                
+                <div className="mt-8 w-full border-t pt-4 text-center">
+                  <p className="text-gray-500 mb-2">아직 계정이 없으신가요?</p>
+                  <button
+                    className="text-[#F7B32B] font-medium"
+                    onClick={() => navigate('/signup')}
+                  >
+                    회원가입하기
+                  </button>
                 </div>
               </div>
-            </div>
-
-            {/* 메뉴 목록 */}
-            <div className="p-4 space-y-4">
-              <div className="border-b pb-2">
-                <button
-                  className="w-full text-left font-bold text-gray-700 flex justify-between items-center"
-                  onClick={() => navigate('/reviews')}
-                >
-                  <span>리뷰 관리</span>
-                  <span className="text-gray-400">→</span>
-                </button>
-              </div>
-
-              <div className="border-b pb-2">
-                <button
-                  className="w-full text-left font-bold text-gray-700 flex justify-between items-center"
-                  onClick={() => navigate('/edit-profile')}
-                >
-                  <span>회원 정보 수정</span>
-                  <span className="text-gray-400">→</span>
-                </button>
-              </div>
-
-              <div className="border-b pb-2">
-                <button
-                  className="w-full text-left font-bold text-gray-700 flex justify-between items-center"
-                  onClick={() => setShowLogoutModal(true)}
-                >
-                  <span>로그아웃</span>
-                  <span className="text-gray-400">→</span>
-                </button>
-              </div>
-
-              <div className="border-b pb-2">
-                <div className="flex justify-between items-center">
-                  <span className="text-gray-500">고객 문의</span>
-                  <span className="text-gray-400">luckeat@example.com</span>
-                </div>
-              </div>
-            </div>
+            )}
           </>
         )}
 


### PR DESCRIPTION
### Description

상세페이지를 포함한 마이페이지를 제외한모든 페이지에 대해 로그인 여부에 관계없이 접근 가능하도록 수정함  
기존 로그인 사용자 전용 보호 라우팅은 **주석 처리**하여 필요 시 쉽게 다시 활성화할 수 있도록 구성

### Related Issues

- Resolves #[이슈 번호를 여기에 입력하세요]

### Changes Made

1. 전체 라우터에서 로그인 유저만 접근 가능했던 보호 로직 주석 처리
   - 예: `<PrivateRoute>` 또는 `useAuth()` 조건 분기 제거
2. 상세페이지(`/store/:id` 등) 포함 마이페이지를 제외한 모든 페이지에서 인증 상태와 관계없이 진입 가능
3. 주석 처리된 보호 로직에는 `// TODO: 운영 환경에서 다시 활성화` 문구 추가
4. 로그인 여부에 따라 보여주는 UI는 유지하되, 접근 제한은 제거

### Screenshots or Video

<!-- 비로그인 상태에서 상세페이지 접근 가능한 화면 등 첨부 가능 -->

### Testing

1. 로그인하지 않은 사용자 상태로 전체 페이지 진입 테스트
2. 기존 로그인 필요 페이지에서 오류 없이 렌더링되는지 확인
3. 로그인 상태일 경우 기존 기능이 정상 작동하는지 확인
4. 주석 처리된 보호 로직 복구 시 정상적으로 다시 제한되는지 확인

### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

### Additional Notes

- 현재는 개발 및 테스트 용도로 **모든 페이지에 대한 공개 접근 허용 상태**
- 운영 환경 배포 전 `// TODO:` 주석 부분을 기준으로 다시 인증 조건을 복원해야 함
