### PR TITLE
가게 상세 페이지에서 공유 링크 생성 시 API URL 사용 및 인증 경로 수정

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,7 +20,6 @@ import EditStorePage from './pages/EditStorePage'
 import { AuthProvider, useAuth } from './context/AuthContext'
 import * as Sentry from '@sentry/react'
 import { hasValidAccessToken } from './utils/jwtUtils'
-
 // 오류 발생 시 보여줄 폴백 컴포넌트
 const FallbackComponent = () => {
   return (
@@ -53,7 +52,10 @@ function AuthWrapper({ children }) {
   useEffect(() => {
     // 현재 경로가 인증이 필요하지 않은 경로인지 확인
     const publicPaths = ['/login', '/signup', '/', '/home', '/map']
-    const isPublicPath = publicPaths.includes(location.pathname)
+    
+    const isStoreDetailPath = /^\/store\/[^/]+$/.test(location.pathname)
+   
+    const isPublicPath = publicPaths.includes(location.pathname) || isStoreDetailPath
 
     // 인증이 필요한 경로에서만 토큰 유효성 검사
     if (!isPublicPath) {

--- a/src/pages/StoreDetailPage.jsx
+++ b/src/pages/StoreDetailPage.jsx
@@ -7,7 +7,7 @@ import { getStoreById } from '../api/storeApi'
 import defaultImage from '../assets/images/luckeat-default.png'
 import bakerDefaultImage from '../assets/images/제빵사디폴트이미지.png'
 import ScrollTopButton from '../components/common/ScrollTopButton'
-
+import { API_DIRECT_URL } from '../config/apiConfig'
 function StoreDetailPage() {
   const { id } = useParams()
   const navigate = useNavigate()
@@ -27,6 +27,7 @@ function StoreDetailPage() {
   const productsRef = useRef(null)
   const storeInfoRef = useRef(null)
   const reviewsRef = useRef(null)
+
   
   // Google Maps 이미지 URL인지 확인하는 함수
   const isGoogleMapsImage = (url) => {
@@ -203,7 +204,10 @@ function StoreDetailPage() {
 
   // 공유 링크 복사
   const handleCopyShareLink = () => {
-    const shareUrl = store.storeUrl || `${window.location.origin}/store/${id}`
+    const shareUrl = store.storeUrl 
+      ? `${API_DIRECT_URL}/s/${store.storeUrl}`
+      : `${API_DIRECT_URL}/store/${id}`;
+
     navigator.clipboard
       .writeText(shareUrl)
       .then(() => {
@@ -792,7 +796,9 @@ function StoreDetailPage() {
             <div className="flex items-center justify-between border rounded-lg p-3 mb-4">
               <input
                 type="text"
-                value={store.storeUrl || `${window.location.origin}/store/${id}`}
+                value={store.storeUrl 
+                  ? `${API_DIRECT_URL}/s/${store.storeUrl}`
+                  : `${API_DIRECT_URL}/store/${id}`}
                 className="flex-1 pr-2 text-sm truncate"
                 readOnly
               />


### PR DESCRIPTION
### Description

가게 상세 페이지에서 공유 링크 생성 시 API URL 사용 및 인증 경로 수정
### Related Issues

<!--
  관련된 이슈 번호를 참고하세요.
  예: Fixes #123, Closes #456
-->

- Closes #133 

### Changes Made


1. 가게 상세 페이지 로그인 없이 접근가능
2. 공유 링크시 url 추가
3. [변경 내용 3]


### Testing
직접 테스트


### Checklist

<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.


