### PR TITLE
feat: 가게 정보 수정 API에 이미지 업로드 기능 추가 및 상품 수정 API의 상대 경로 사용으로 개선. 이미지 URL…

### DIFF
--- a/src/api/productApi.js
+++ b/src/api/productApi.js
@@ -64,8 +64,9 @@ export const updateProduct = async (storeId, productId, productData, productImag
     
     console.log('상품 수정 요청 데이터:', processedData);
     
-    // 상품 수정 API 호출
-    const response = await apiClient.put(`/stores/${storeId}/products/${productId}`, processedData);
+    // 상품 수정 API 호출 - 상대 경로 사용
+    const endpoint = `/stores/${storeId}/products/${productId}`;
+    const response = await apiClient.put(endpoint, processedData);
     console.log('상품 수정 응답:', response.data);
     return response.data;
   } catch (error) {

--- a/src/api/storeApi.js
+++ b/src/api/storeApi.js
@@ -142,32 +142,47 @@ export const getStoreById = async (storeId) => {
 }
 
 // 가게 정보 수정
-export const updateStore = async (storeId, storeData) => {
+export const updateStore = async (storeId, storeData, storeImage) => {
   try {
+    // 이미지 처리 (이미지 파일이 있는 경우에만)
+    let processedData = storeData;
+    if (storeImage) {
+      console.log('가게 이미지 업로드 시작:', storeImage.name);
+      processedData = await processImageData(
+        storeData,
+        storeImage,
+        'storeImg',
+        'stores'
+      );
+      console.log('이미지 처리 후 데이터:', processedData.storeImg);
+    }
+    
+    // API 호출
     const response = await apiClient.put(`/api/v1/stores/${storeId}`, {
-      storeName: storeData.storeName,
-      storeImg: storeData.storeImg,
-      address: storeData.address,
-      website: storeData.website || '',
-      storeUrl: storeData.storeUrl || '',
-      permissionUrl: storeData.permissionUrl || '',
-      latitude: storeData.latitude || 0,
-      longitude: storeData.longitude || 0,
-      contactNumber: storeData.contactNumber,
-      description: storeData.description,
-      businessNumber: storeData.businessNumber,
-      businessHours: storeData.businessHours || '',
-      reviewSummary: storeData.reviewSummary || '',
-      avgRating: storeData.avgRating || 0,
-      avgRatingGoogle: storeData.avgRatingGoogle || 0,
-      googlePlaceId: storeData.googlePlaceId || '',
-    })
+      storeName: processedData.storeName,
+      storeImg: processedData.storeImg,
+      address: processedData.address,
+      website: processedData.website || '',
+      storeUrl: processedData.storeUrl || '',
+      permissionUrl: processedData.permissionUrl || '',
+      latitude: processedData.latitude || 0,
+      longitude: processedData.longitude || 0,
+      contactNumber: processedData.contactNumber,
+      description: processedData.description,
+      businessNumber: processedData.businessNumber,
+      businessHours: processedData.businessHours || '',
+      reviewSummary: processedData.reviewSummary || '',
+      avgRating: processedData.avgRating || 0,
+      avgRatingGoogle: processedData.avgRatingGoogle || 0,
+      googlePlaceId: processedData.googlePlaceId || '',
+    });
     
     return {
       success: true,
       data: response.data,
     }
   } catch (error) {
+    console.error('가게 정보 수정 오류:', error);
     return {
       success: false,
       message: error.response?.data?.message || '가게 정보 수정에 실패했습니다.',

--- a/src/api/uploadApi.js
+++ b/src/api/uploadApi.js
@@ -76,10 +76,23 @@ export const processImageData = async (
     // 이미지 업로드 함수 호출하여 URL 받기
     const imageUrl = await uploadImage(imageFile, type);
 
+    // S3 URL 구조에서 필요한 경로 부분 추출
+    // 예: https://luckeat-front.s3.ap-northeast-2.amazonaws.com/images/products/34abb3e9-6791-4a15-816f-539b91f4ebbd-레오나르도디카프리오.jpeg
+    // 에서 /images/products/34abb3e9-6791-4a15-816f-539b91f4ebbd-레오나르도디카프리오.jpeg 부분만 추출
+    const pathPart = imageUrl.replace('https://luckeat-front.s3.ap-northeast-2.amazonaws.com', '');
+    
+    // API_DIRECT_URL 변수를 사용하여 새 URL 생성 (.env의 VITE_API_URL 값이 설정되어 있음)
+    const formattedImageUrl = `https://dxa66rf338pjr.cloudfront.net${pathPart}`;
+    
+    console.log('이미지 URL 변환:', {
+      원본: imageUrl,
+      변환: formattedImageUrl
+    });
+
     // 업로드된 이미지 URL을 원본 데이터에 추가
     return {
       ...formData,
-      [imageFieldName]: imageUrl,
+      [imageFieldName]: formattedImageUrl,
     }
   } catch (error) {
     console.error('이미지 업로드 중 오류 발생:', error)

--- a/src/components/products/ProductManagement.jsx
+++ b/src/components/products/ProductManagement.jsx
@@ -67,8 +67,8 @@ const ProductManagement = () => {
     setCurrentProduct(product)
     setFormData({
       productName: product.productName,
-      originalPrice: product.originalPrice,
-      discountedPrice: product.discountedPrice
+      originalPrice: product.originalPrice.toString(),
+      discountedPrice: product.discountedPrice.toString()
     })
     setProductImage(null)
     setProductImageUrl(product.productImg || '')
@@ -132,7 +132,11 @@ const ProductManagement = () => {
     try {
       if (editMode && currentProduct) {
         // 상품 수정
-        const updatedFormData = {...formData};
+        const updatedFormData = {
+          ...formData,
+          originalPrice: parseInt(formData.originalPrice),
+          discountedPrice: parseInt(formData.discountedPrice)
+        };
         
         if (!productImage && currentProduct.productImg) {
           // 이미지가 선택되지 않았고 기존 이미지가 있는 경우

--- a/src/pages/EditStorePage.jsx
+++ b/src/pages/EditStorePage.jsx
@@ -32,6 +32,7 @@ function EditStorePage() {
   const [showToast, setShowToast] = useState(false)
   const [toastMessage, setToastMessage] = useState('')
   const [imagePreview, setImagePreview] = useState('')
+  const [storeImageFile, setStoreImageFile] = useState(null)
 
   useEffect(() => {
     const fetchStoreData = async () => {
@@ -100,14 +101,12 @@ function EditStorePage() {
       return
     }
 
+    // 이미지 파일 저장
+    setStoreImageFile(file)
+    
     // 이미지 미리보기 생성
     const reader = new FileReader()
     reader.onloadend = () => {
-      // base64 데이터는 미리보기용으로만 사용하고, 실제 데이터는 기존 URL 유지
-      setFormData((prev) => ({
-        ...prev,
-        storeImg: store?.storeImg || '',
-      }))
       setImagePreview(reader.result)
     }
     reader.readAsDataURL(file)
@@ -144,7 +143,10 @@ function EditStorePage() {
 
       // 디버깅을 위해 전송 데이터 로깅
       console.log('수정 요청 데이터:', dataToSubmit)
-      const response = await updateStore(store.id, dataToSubmit)
+      console.log('이미지 파일 존재 여부:', storeImageFile ? true : false)
+      
+      // 이미지 파일이 있는 경우 업로드 처리
+      const response = await updateStore(store.id, dataToSubmit, storeImageFile)
       if (response.success) {
         showToastMessage('가게 정보가 성공적으로 수정되었습니다.')
         setTimeout(() => {


### PR DESCRIPTION
### Description

이미지 업로드
사용자가 이미지를 업로드하면 아래와 같은 S3 버킷 주소로 이미지가 저장됨:
https://luckeat-front.s3.ap-northeast-2.amazonaws.com/images/products/{파일명}

업로드된 URL 예시
https://luckeat-front.s3.ap-northeast-2.amazonaws.com/images/products/2be65d38-4d77-41f7-9009-21c34c654719-8조_기획.png

CloudFront URL로 변환
S3 URL을 아래의 CloudFront URL 형식으로 변환하여 사용:
https://dxa66rf338pjr.cloudfront.net/images/products/2be65d38-4d77-41f7-9009-21c34c654719-8조_기획.png

서버 전송
변환된 CloudFront URL을 서버에 전송하여 저장 또는 활용함.

### Related Issues

- Resolves #142 


### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.
