### PR TITLE
API 경로 명명 규칙 통일: /reservations → /reservation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -95,8 +95,8 @@ function AppRoutes() {
         <Route path="/edit-profile" element={<EditProfilePage />} />
         <Route path="/store/:storeId/products" element={<ProductManagementPage />} />
         <Route path="/edit-store" element={<EditStorePage />} />
-        <Route path="/store/:storeId/reservations" element={<StoreReservationsPage />} />
-        <Route path="/reservations" element={<UserReservationsPage />} />
+        <Route path="/store/:storeId/reservation" element={<StoreReservationsPage />} />
+        <Route path="/reservation" element={<UserReservationsPage />} />
       </Routes>
     </AuthWrapper>
   )

--- a/src/pages/BusinessPage.jsx
+++ b/src/pages/BusinessPage.jsx
@@ -313,7 +313,7 @@ function BusinessPage() {
                     onClick={() => {
                       if (storeData) {
                         console.log('가게 예약 리스트 이동:', storeData.id);
-                        navigate(`/store/${storeData.id}/reservations`);
+                        navigate(`/store/${storeData.id}/reservation`);
                       }
                     }}
                     disabled={!storeData}

--- a/src/pages/UserReservationsPage.jsx
+++ b/src/pages/UserReservationsPage.jsx
@@ -306,7 +306,7 @@ const UserReservationsPage = () => {
         {/* 상단 정보 영역 */}
         <div className="bg-white p-4 shadow-sm">
           <h1 className="text-xl font-bold text-gray-800 mb-2">
-            나의 예약 목록
+            나의 예약
           </h1>
           <p className="text-sm text-gray-600">
             모든 예약 내역을 확인하고 관리할 수 있습니다.


### PR DESCRIPTION
# [FE] API 경로 명명 규칙 통일: /reservations → /reservation

## 📌 어떤 기능인가요?

RESTful한 명명 규칙을 지키기 위해 기존에 사용 중인 `/reservations` 복수형 경로를 `/reservation` 단수형으로 통일

---

## ✅ 작업 상세 내용

- [ ] 프론트 전반에서 사용 중인 `/reservations` 경로를 `/reservation`으로 변경
- [ ] 관련 API 요청 URL 및 라우팅 수정
- [ ] 변경된 경로에 따른 백엔드 응답 정상 연동 확인
- [ ] `/reservation/status`, `/reservation/{user_id}` 등 기존 단수형 경로와 통일되도록 정리

---

## 📎 참고할만한 자료 (선택)

> 없음

---

## 🎯 예상 마감일

- `2025-03-28`

---

## 🏷 관련 이슈 (선택)

> 없음

---

👀 **추가 설명이 필요한 경우, 아래에 자유롭게 작성해주세요!**

- API 명세 문서도 함께 업데이트 필요 시 별도 이슈 생성  
- 추후 POST/GET/DELETE 요청이 일관되게 동작하는지 테스트 필요
