### PR TITLE
네비게이션 바 복원 및 인증 페이지 UI 원복

### DIFF
--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -87,103 +87,107 @@ function LoginPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-100">
-      <Navigation />
-      <Header title="로그인" showBackButton={true} />
-      <main className="container mx-auto py-8 px-4">
-        <div className="max-w-md mx-auto bg-white rounded-lg shadow-md p-6">
-          {/* 세션 메시지 표시 - 개선된 스타일 */}
-          {sessionMessage && (
-            <div className="mb-4 p-3 bg-yellow-100 text-yellow-800 rounded-md border border-yellow-200">
-              <p className="font-medium">{sessionMessage}</p>
-            </div>
-          )}
+    <div className="flex flex-col h-full">
+      {/* 헤더 */}
+      <Header title="로그인" />
 
-          {/* 오류 메시지 표시 - 개선된 스타일 */}
-          {error && (
-            <div className="mb-4 p-3 bg-red-100 text-red-800 rounded-md border border-red-200">
-              <p className="font-medium">{error}</p>
-            </div>
-          )}
+      <div className="flex-1 p-4 overflow-y-auto">
+        {/* 세션 만료 메시지 */}
+        {sessionMessage && (
+          <div
+            className="bg-yellow-100 border-l-4 border-yellow-500 text-yellow-700 p-4 mb-4 rounded"
+            role="alert"
+          >
+            <p>{sessionMessage}</p>
+          </div>
+        )}
 
-          {/* 로그인 폼 */}
-          <form onSubmit={handleLogin} className="space-y-6 mt-4">
-            {/* 로그인 필드들 */}
-            <div className="border rounded-lg p-4 space-y-4">
-              {/* 이메일 입력 */}
-              <div>
-                <label className="block text-sm font-medium mb-1">
-                  이메일 주소
-                </label>
-                <input
-                  type="email"
-                  id="email"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  className="w-full p-3 bg-gray-100 rounded-lg"
-                  placeholder="이메일 주소를 입력해주세요"
-                  required
+        {/* 오류 메시지 */}
+        {error && (
+          <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mt-4 mb-4">
+            {error}
+          </div>
+        )}
+
+        {/* 로그인 폼 */}
+        <form onSubmit={handleLogin} className="space-y-6 mt-4">
+          {/* 로그인 필드들 */}
+          <div className="border rounded-lg p-4 space-y-4">
+            {/* 이메일 입력 */}
+            <div>
+              <label className="block text-sm font-medium mb-1">
+                이메일 주소
+              </label>
+              <input
+                type="email"
+                id="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className="w-full p-3 bg-gray-100 rounded-lg"
+                placeholder="이메일 주소를 입력해주세요"
+                required
+              />
+            </div>
+
+            {/* 비밀번호 입력 */}
+            <div>
+              <label className="block text-sm font-medium mb-1">
+                비밀번호
+              </label>
+              <input
+                type="password"
+                id="password"
+                value={password}
+                onChange={handlePasswordInput}
+                className="w-full p-3 bg-gray-100 rounded-lg"
+                placeholder="비밀번호를 입력해주세요"
+                required
+              />
+            </div>
+          </div>
+
+          {/* 로그인 버튼 */}
+          <button
+            type="submit"
+            className="w-5/6 py-2 bg-yellow-500 text-white font-bold rounded-lg mx-auto block"
+            disabled={loading}
+          >
+            {loading ? '로그인 중...' : '로그인'}
+          </button>
+
+          {/* 카카오 로그인 버튼 */}
+          <div className="mt-4">
+            <button
+              type="button"
+              onClick={() => {
+                window.location.href = `${API_DIRECT_URL}/oauth2/authorization/kakao`
+              }}
+              className="w-full"
+            >
+              <div className="flex justify-center items-center">
+                <img
+                  src={kakaoLoginImage}
+                  alt="카카오 로그인"
+                  className="w-5/6 h-auto rounded-lg"
                 />
               </div>
-
-              {/* 비밀번호 입력 */}
-              <div>
-                <label className="block text-sm font-medium mb-1">
-                  비밀번호
-                </label>
-                <input
-                  type="password"
-                  id="password"
-                  value={password}
-                  onChange={handlePasswordInput}
-                  className="w-full p-3 bg-gray-100 rounded-lg"
-                  placeholder="비밀번호를 입력해주세요"
-                  required
-                />
-              </div>
-            </div>
-
-            {/* 로그인 버튼 */}
-            <button
-              type="submit"
-              className="w-5/6 py-2 bg-yellow-500 text-white font-bold rounded-lg mx-auto block"
-              disabled={loading}
-            >
-              {loading ? '로그인 중...' : '로그인'}
-            </button>
-
-            {/* 카카오 로그인 버튼 */}
-            <div className="mt-4">
-              <button
-                type="button"
-                onClick={() => {
-                  window.location.href = `${API_DIRECT_URL}/oauth2/authorization/kakao`
-                }}
-                className="w-full"
-              >
-                <div className="flex justify-center items-center">
-                  <img
-                    src={kakaoLoginImage}
-                    alt="카카오 로그인"
-                    className="w-5/6 h-auto rounded-lg"
-                  />
-                </div>
-              </button>
-            </div>
-          </form>
-
-          {/* 회원가입 링크 */}
-          <div className="mt-8 text-center">
-            <p className="text-sm text-gray-600 mb-2">계정이 없으신가요?</p>
-            <button
-              className="px-4 py-2 bg-gray-200 text-gray-700 rounded-lg"
-              onClick={() => navigate('/signup')}
-            >
-              회원가입하기
             </button>
           </div>
+        </form>
+
+        {/* 회원가입 링크 */}
+        <div className="mt-8 text-center">
+          <p className="text-sm text-gray-600 mb-2">계정이 없으신가요?</p>
+          <button
+            className="px-4 py-2 bg-gray-200 text-gray-700 rounded-lg"
+            onClick={() => navigate('/signup')}
+          >
+            회원가입하기
+          </button>
         </div>
-      </main>
+      </div>
+
+      <Navigation />
     </div>
   )
 }

--- a/src/pages/SignupPage.jsx
+++ b/src/pages/SignupPage.jsx
@@ -218,139 +218,139 @@ function SignupPage() {
   console.log('SignupPage 렌더링, 팝업 상태:', showSuccessPopup)
 
   return (
-    <div className="min-h-screen bg-gray-100">
-      <Navigation />
-      <Header title="회원가입" showBackButton={true} />
-      <main className="container mx-auto py-8 px-4">
-        <div className="max-w-md mx-auto bg-white rounded-lg shadow-md p-6">
-          {/* 오류 메시지 표시 - 개선된 스타일 */}
-          {error && (
-            <div className="mb-4 p-3 bg-red-100 text-red-800 rounded-md border border-red-200">
-              <p className="font-medium">{error}</p>
-            </div>
-          )}
+    <div className="flex flex-col h-full">
+      {/* 헤더 */}
+      <Header title="회원가입" />
 
-          {/* 회원가입 폼 */}
-          <form onSubmit={handleSignup} className="space-y-6">
-            {/* 회원 유형 선택 */}
-            <div className="border border-red-500 rounded-lg p-3">
-              <div className="flex items-center space-x-4">
-                <label className="flex items-center">
-                  <input
-                    type="radio"
-                    name="userType"
-                    value="일반"
-                    checked={userType === '일반'}
-                    onChange={() => setUserType('일반')}
-                    className="mr-2"
-                  />
-                  <span className="flex items-center">
-                    <span className="w-4 h-4 bg-yellow-500 rounded-full mr-1"></span>
-                    일반 사용자
-                  </span>
-                </label>
-                <label className="flex items-center">
-                  <input
-                    type="radio"
-                    name="userType"
-                    value="사업자"
-                    checked={userType === '사업자'}
-                    onChange={() => setUserType('사업자')}
-                    className="mr-2"
-                  />
-                  <span>사업자</span>
-                </label>
-              </div>
-            </div>
-
-            {/* 나머지 폼 필드들 */}
-            <div className="border rounded-lg p-4 space-y-4">
-              <div>
-                <label className="block text-sm font-medium mb-1">
-                  이메일 주소
-                </label>
-                <input
-                  type="email"
-                  placeholder="이메일 주소를 입력해주세요."
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  className="w-full p-3 bg-gray-100 rounded-lg"
-                  required
-                />
-                <p className="text-xs text-gray-500 mt-1">
-                  (예: example@example.com)
-                </p>
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium mb-1">닉네임</label>
-                <input
-                  type="text"
-                  placeholder="닉네임을 입력해주세요."
-                  value={nickname}
-                  onChange={(e) => setNickname(e.target.value)}
-                  className="w-full p-3 bg-gray-100 rounded-lg"
-                  required
-                />
-                <p className="text-xs text-gray-500 mt-1">
-                  2~10자 이내로 입력해주세요.
-                </p>
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium mb-1">비밀번호</label>
-                <input
-                  type="password"
-                  placeholder="비밀번호를 입력해주세요."
-                  value={password}
-                  onChange={handlePasswordInput}
-                  className="w-full p-3 bg-gray-100 rounded-lg"
-                  required
-                />
-                <p className="text-xs text-gray-500 mt-1">
-                  비밀번호는 8자 이상, 20자 이하이며, 영어 소문자, 숫자를 각각
-                  최소 1개 포함해야 합니다.
-                </p>
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium mb-1">
-                  비밀번호 확인
-                </label>
-                <input
-                  type="password"
-                  placeholder="비밀번호를 다시 입력해주세요."
-                  value={confirmPassword}
-                  onChange={handleConfirmPasswordInput}
-                  className="w-full p-3 bg-gray-100 rounded-lg"
-                  required
-                />
-              </div>
-            </div>
-
-            <button
-              type="submit"
-              className="w-full py-3 bg-yellow-500 text-white font-bold rounded-lg"
-              disabled={loading}
-            >
-              {loading ? '처리 중...' : '회원가입'}
-            </button>
-          </form>
-
-          <div className="mt-8 text-center">
-            <p className="text-sm text-gray-600 mb-2">이미 회원이신가요?</p>
-            <button
-              className="px-4 py-2 bg-gray-200 text-gray-700 rounded-lg"
-              onClick={() => navigate('/login')}
-            >
-              로그인하기
-            </button>
+      <div className="flex-1 p-4 overflow-y-auto">
+        {error && (
+          <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mt-4">
+            {error}
           </div>
-        </div>
-      </main>
+        )}
 
+        {/* 회원가입 폼 */}
+        <form onSubmit={handleSignup} className="space-y-6 mt-4">
+          {/* 회원 유형 선택 */}
+          <div className="border border-red-500 rounded-lg p-3">
+            <div className="flex items-center space-x-4">
+              <label className="flex items-center">
+                <input
+                  type="radio"
+                  name="userType"
+                  value="일반"
+                  checked={userType === '일반'}
+                  onChange={() => setUserType('일반')}
+                  className="mr-2"
+                />
+                <span className="flex items-center">
+                  <span className="w-4 h-4 bg-yellow-500 rounded-full mr-1"></span>
+                  일반 사용자
+                </span>
+              </label>
+              <label className="flex items-center">
+                <input
+                  type="radio"
+                  name="userType"
+                  value="사업자"
+                  checked={userType === '사업자'}
+                  onChange={() => setUserType('사업자')}
+                  className="mr-2"
+                />
+                <span>사업자</span>
+              </label>
+            </div>
+          </div>
+
+          {/* 나머지 폼 필드들 */}
+          <div className="border rounded-lg p-4 space-y-4">
+            <div>
+              <label className="block text-sm font-medium mb-1">
+                이메일 주소
+              </label>
+              <input
+                type="email"
+                placeholder="이메일 주소를 입력해주세요."
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className="w-full p-3 bg-gray-100 rounded-lg"
+                required
+              />
+              <p className="text-xs text-gray-500 mt-1">
+                (예: example@example.com)
+              </p>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium mb-1">닉네임</label>
+              <input
+                type="text"
+                placeholder="닉네임을 입력해주세요."
+                value={nickname}
+                onChange={(e) => setNickname(e.target.value)}
+                className="w-full p-3 bg-gray-100 rounded-lg"
+                required
+              />
+              <p className="text-xs text-gray-500 mt-1">
+                2~10자 이내로 입력해주세요.
+              </p>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium mb-1">비밀번호</label>
+              <input
+                type="password"
+                placeholder="비밀번호를 입력해주세요."
+                value={password}
+                onChange={handlePasswordInput}
+                className="w-full p-3 bg-gray-100 rounded-lg"
+                required
+              />
+              <p className="text-xs text-gray-500 mt-1">
+                비밀번호는 8자 이상, 20자 이하이며, 영어 소문자, 숫자를 각각
+                최소 1개 포함해야 합니다.
+              </p>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium mb-1">
+                비밀번호 확인
+              </label>
+              <input
+                type="password"
+                placeholder="비밀번호를 다시 입력해주세요."
+                value={confirmPassword}
+                onChange={handleConfirmPasswordInput}
+                className="w-full p-3 bg-gray-100 rounded-lg"
+                required
+              />
+            </div>
+          </div>
+
+          <button
+            type="submit"
+            className="w-full py-3 bg-yellow-500 text-white font-bold rounded-lg"
+            disabled={loading}
+          >
+            {loading ? '처리 중...' : '회원가입'}
+          </button>
+        </form>
+
+        <div className="mt-8 text-center">
+          <p className="text-sm text-gray-600 mb-2">이미 회원이신가요?</p>
+          <button
+            className="px-4 py-2 bg-gray-200 text-gray-700 rounded-lg"
+            onClick={() => navigate('/login')}
+          >
+            로그인하기
+          </button>
+        </div>
+      </div>
+      
       {/* 회원가입 성공 팝업 - renderSuccessPopup 함수 사용 */}
       {renderSuccessPopup()}
+
+      <Navigation />
     </div>
   )
 }


### PR DESCRIPTION
### Description

이전에 변경되었던 네비게이션 바와 로그인/회원가입 페이지의 UI를 원래 디자인으로 되돌림  
레이아웃 깨짐 및 스타일 충돌 방지를 위해 기존 안정적인 형태로 복원함

### Related Issues

- Resolves #[이슈 번호를 입력하세요]

### Changes Made

1. 네비게이션 바 기존 디자인 및 위치로 복원
2. 로그인 / 회원가입 페이지 UI를 원래 스타일로 되돌림
3. 불필요한 임시 스타일 또는 테스트 코드 제거

### Screenshots or Video

<!-- 네비게이션 바 및 인증 페이지 UI 복원 후 스크린샷 첨부 권장 -->

### Testing

1. 모든 페이지에서 네비게이션 바 정상 표시 확인
2. 로그인 / 회원가입 페이지 UI 정상 렌더링 확인
3. 모바일 환경에서 UI 깨짐 없는지 확인

### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드
