### PR TITLE
177 fe 회원정보수정 페이지 스크롤 오류 수정

### DIFF
--- a/src/pages/EditProfilePage.jsx
+++ b/src/pages/EditProfilePage.jsx
@@ -292,13 +292,13 @@ function EditProfilePage() {
         <h1 className="text-2xl font-bold text-center mb-6">회원정보 수정</h1>
 
         {/* 이메일 표시 (수정 불가) */}
-        <div className="mb-6">
+        <div className="mb-2">
           <label className="block text-sm font-medium mb-1">이메일</label>
           <input
             type="email"
             value={user?.email || ''}
             disabled
-            className="w-full p-3 bg-gray-300 rounded-lg border border-gray-300 text-gray-500 font-medium"
+            className="w-full p-2 bg-gray-300 rounded-lg border border-gray-300 text-gray-500 font-medium"
           />
           <p className="text-gray-500 text-xs mt-1">
             * 이메일은 수정할 수 없습니다.
@@ -312,7 +312,7 @@ function EditProfilePage() {
             type="text"
             value={nickname}
             onChange={handleNicknameChange}
-            className="w-full p-3 bg-gray-100 rounded-lg border border-gray-300"
+            className="w-full p-2 bg-gray-100 rounded-lg border border-gray-300"
           />
           {isNicknameSame && (
             <p className="text-gray-500 text-sm mt-1">
@@ -349,7 +349,7 @@ function EditProfilePage() {
             value={currentPassword}
             onChange={handleCurrentPasswordChange}
             placeholder="현재 비밀번호를 입력해주세요."
-            className="w-full p-3 bg-gray-100 rounded-lg border border-gray-300 mb-2"
+            className="w-full p-2 bg-gray-100 rounded-lg border border-gray-300 mb-2"
           />
           {currentPasswordError && (
             <p className="text-red-500 text-sm mb-2">
@@ -363,7 +363,7 @@ function EditProfilePage() {
             value={newPassword}
             onChange={handlePasswordChange}
             placeholder="새로운 비밀번호를 입력해주세요."
-            className="w-full p-3 bg-gray-100 rounded-lg border border-gray-300 mb-2"
+            className="w-full p-2 bg-gray-100 rounded-lg border border-gray-300 mb-2"
           />
           {passwordError && (
             <p className="text-red-500 text-sm mb-2">* {passwordError}</p>
@@ -377,7 +377,7 @@ function EditProfilePage() {
             value={confirmPassword}
             onChange={handleConfirmPasswordChange}
             placeholder="비밀번호를 다시 한번 입력해주세요."
-            className="w-full p-3 bg-gray-100 rounded-lg border border-gray-300"
+            className="w-full p-2 bg-gray-100 rounded-lg border border-gray-300"
           />
           {passwordsNotMatch && (
             <p className="text-red-500 text-sm mt-1">

--- a/src/pages/EditProfilePage.jsx
+++ b/src/pages/EditProfilePage.jsx
@@ -288,7 +288,7 @@ function EditProfilePage() {
     <div className="flex flex-col h-full bg-white">
       <Header title="회원정보 수정" onBack={() => navigate('/mypage')} />
 
-      <div className="flex-1 p-4">
+      <div className="flex-1 p-4 overflow-y-auto">
         <h1 className="text-2xl font-bold text-center mb-6">회원정보 수정</h1>
 
         {/* 이메일 표시 (수정 불가) */}


### PR DESCRIPTION
### Description

회원정보수정페이지의 스크롤 오류를 해결하였습니다.
추가적으로 입력박스 간격을 조정하였습니다.

### Related Issues

- Closes #177 

### Changes Made

1. 페이지 스크롤 오류 수정
2. 입력박스 간격 조정

### Screenshots or Video

<img width="1512" alt="스크린샷 2025-04-01 오후 5 17 41" src="https://github.com/user-attachments/assets/885e4d28-e7ba-4420-a0d5-ae9bf6d80695" />

<img width="1512" alt="스크린샷 2025-04-01 오후 5 29 21" src="https://github.com/user-attachments/assets/a2a8b2b3-76d8-4e42-9c83-f8784ae2bd5b" />

틀린그림찾기아님.ㅋ

### Testing

로컬에서 테스트 완료했습니다.

### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

### Additional Notes

<!--
  리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요.
-->
