### PR TITLE
가게 수정페이지 불필요한 문구 삭제

### DIFF
--- a/src/pages/EditStorePage.jsx
+++ b/src/pages/EditStorePage.jsx
@@ -335,29 +335,6 @@ function EditStorePage() {
 
       <div className="flex-1 overflow-y-auto">
         <form onSubmit={handleSubmit}>
-          {/* 안내 문구 */}
-          <div className="bg-blue-50 border-b border-blue-100 p-4">
-            <div className="flex items-start">
-              <svg
-                className="h-5 w-5 text-blue-400 mt-0.5 mr-2"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 20 20"
-                fill="currentColor"
-              >
-                <path
-                  fillRule="evenodd"
-                  d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"
-                  clipRule="evenodd"
-                />
-              </svg>
-              <p className="text-sm text-blue-700">
-                가게 정보는 구글 맵에서 가져오는 데이터입니다.
-                <br />
-                주소, 영업시간 등 기본 정보 변경이 필요하시다면 구글 맵에서 수정해 주세요.
-              </p>
-            </div>
-          </div>
-
           {/* 가게 이미지 */}
           <div className="relative h-44 mx-4 mt-4">
             {imagePreview ? (


### PR DESCRIPTION
### Description

EditStorePage에서 더 이상 구글 맵을 통해서만 수정이 필요한 구조가 아니기 때문에,  
기존 안내 문구와 관련 UI 요소를 모두 제거하고 사용자에게 혼동을 주지 않도록 개선함

### Related Issues

- Resolves #[이슈 번호를 입력하세요]

### Changes Made

1. 다음 안내 문구 및 관련 UI 요소 제거:
   > "가게 정보는 구글 맵에서 가져오는 데이터입니다. 주소, 영업시간 등 기본 정보 변경이 필요하시다면 구글 맵에서 수정해 주세요."
2. 해당 안내와 관련된 조건부 렌더링 코드 및 스타일 제거
3. 가게 정보 직접 수정 기능이 가능하므로 기존 불가한 전제로 작성된 문구 정리

### Screenshots or Video

<!-- 문구 제거 전/후 비교 캡처 가능 시 첨부 권장 -->

### Testing

1. 페이지 접근 시 안내 문구가 더 이상 보이지 않는지 확인
2. 주소/영업시간 입력 필드가 정상적으로 표시되고 수정 가능한지 확인
3. 수정 후 저장 시 백엔드 반영 여부 확인
4. UI 레이아웃에 깨짐 없는지 확인

### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

### Additional Notes

- 구글 맵 기반 정보 연동이 아닌 자율 입력 방식으로 구조 변경됨
- 관련 주석 및 문구도 함께 제거하여 유지보수 간결화
