### PR TITLE
style: 제로웨이스트 뱃지 UI 개선

### DIFF
--- a/src/pages/StoreReservationsPage.jsx
+++ b/src/pages/StoreReservationsPage.jsx
@@ -4,7 +4,7 @@ import Header from '../components/layout/Header'
 import Navigation from '../components/layout/Navigation'
 import { useAuth } from '../context/AuthContext'
 import { formatDateTime } from '../utils/dateUtils'
-import { 
+import {
   getStoreReservations,
   updateReservationStatus,
 } from '../api/reservationApi'
@@ -81,7 +81,7 @@ const StoreReservationsPage = () => {
     try {
       setLoading(true)
       const response = await getStoreReservations(storeId)
-      
+
       if (response.success) {
         // 최신순으로 정렬 (createdAt 기준 내림차순)
         const sortedReservations = [...response.data].sort((a, b) => {
@@ -105,22 +105,23 @@ const StoreReservationsPage = () => {
   const handleReservationStatus = async (reservationId, status) => {
     try {
       setLoading(true)
-      
+
       const statusData = {
         reservationId,
         status,
       }
-      
+
       const response = await updateReservationStatus(statusData)
-      
+
       if (response.success) {
-        const message = status === 'CONFIRMED'
-          ? '예약이 승인되었습니다'
-          : '예약이 거절되었습니다'
-        
+        const message =
+          status === 'CONFIRMED'
+            ? '예약이 승인되었습니다'
+            : '예약이 거절되었습니다'
+
         const toastType = status === 'CONFIRMED' ? 'success' : 'error'
         showToastMessage(message, toastType)
-        
+
         setReservations((prev) =>
           prev.map((reservation) =>
             reservation.id === reservationId
@@ -162,9 +163,10 @@ const StoreReservationsPage = () => {
     setActiveFilter(newFilter)
   }
 
-  const filteredReservations = filter === 'ALL'
-    ? reservations
-    : reservations.filter((r) => r.status === filter)
+  const filteredReservations =
+    filter === 'ALL'
+      ? reservations
+      : reservations.filter((r) => r.status === filter)
 
   const getStatusText = (status) => {
     switch (status) {
@@ -280,20 +282,23 @@ const StoreReservationsPage = () => {
                   <div className="p-4">
                     <div className="flex justify-between items-start">
                       <div>
-                        <h3 className="font-bold text-gray-800">
-                          {reservation.userNickname || reservation.customerName || '고객'}
+                        <h3 className="font-bold text-gray-800 flex items-center gap-2">
+                          {reservation.userNickname ||
+                            reservation.customerName ||
+                            '고객'}
+                          {reservation.isZerowaste && (
+                            <span className="text-xs bg-green-100 text-green-700 px-2 py-0.5 rounded-full">
+                              제로웨이스트
+                            </span>
+                          )}
                         </h3>
                         <p className="text-sm text-gray-500 mt-1">
-                          {reservation.productName || '상품'} {reservation.quantity || 1}개
+                          {reservation.productName || '상품'}{' '}
+                          {reservation.quantity || 1}개
                         </p>
                         <p className="text-sm text-gray-500">
                           {formatDateTime(reservation.createdAt)}
                         </p>
-                        {reservation.isZeroWaste && (
-                          <p className="text-xs text-green-600 font-medium mt-1">
-                            제로웨이스트 손님 (포장용기 지참)
-                          </p>
-                        )}
                       </div>
                       <div className="flex items-center">
                         <ReservationStatusBadge status={reservation.status} />
@@ -331,24 +336,6 @@ const StoreReservationsPage = () => {
                               {reservation.id}
                             </span>
                           </p>
-                          <p className="text-sm">
-                            <span className="font-medium text-gray-700">
-                              연락처:
-                            </span>{' '}
-                            <span className="text-gray-600">
-                              {reservation.phone || '정보 없음'}
-                            </span>
-                          </p>
-                          {reservation.isZeroWaste && (
-                            <p className="text-sm">
-                              <span className="font-medium text-green-700">
-                                제로웨이스트:
-                              </span>{' '}
-                              <span className="text-green-600">
-                                포장용기 지참
-                              </span>
-                            </p>
-                          )}
                           {reservation.notes && (
                             <p className="text-sm">
                               <span className="font-medium text-gray-700">


### PR DESCRIPTION
### Description

예약 확인 페이지의 연락처 정보칸을 삭제하고 제로웨이스트 손님 표시 UI를 개선했습니다. 

### Related Issues

- Closes #153

### Changes Made

1. 연락처 정보칸을 삭제했습니다.
2. 제로웨이스트 손님 표시 UI 변경
변수명 불일치로 undefined 뜨던 제로웨이스트여부를 수정하여 노출되도록하였습니다.
   - 기존: 닉네임 아래 문장으로 표시 ("포장용기를 지참하는 손님분이에요!")
   - 변경: 닉네임 옆에 뱃지 형태로 표시 (초록색 배경의 "제로웨이스트" 뱃지)

### Screenshots or Video

<img width="1512" alt="스크린샷 2025-04-02 오전 1 17 47" src="https://github.com/user-attachments/assets/3b244d2f-7dc3-4eb4-926b-845bfc89b67b" />

### Testing

1. 제로웨이스트 손님의 예약 건에서 뱃지가 정상적으로 표시되는지 확인
2. 일반 손님의 예약 건에서는 뱃지가 표시되지 않는지 확인

### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

### Additional Notes

추후에 회원가입시 연락처를 받아서 예약시 전달해주는 방향도 고려해보면 좋을것같스빈다.
