### PR TITLE
영업시간 표시 개선: \n 문자열을 실제 줄바꿈으로 변환

### DIFF
--- a/src/pages/StoreDetailPage.jsx
+++ b/src/pages/StoreDetailPage.jsx
@@ -738,7 +738,9 @@ function StoreDetailPage() {
               <span className="block mb-1 font-bold">🏷️ 영업시간</span>
               <div className="mt-2 ml-2">
                 {store.businessHours ? (
-                  <p className="py-1">{store.businessHours}</p>
+                  <div className="py-1 whitespace-pre-line">
+                    {store.businessHours.replace(/\\n/g, '\n')}
+                  </div>
                 ) : (
                   <p className="py-1 text-gray-500">영업시간 정보가 없습니다.</p>
                 )}


### PR DESCRIPTION
## ✨ Description

가게 상세페이지 내 영업시간 표기 방식 개선을 위한 수정입니다.  
기존에는 백엔드에서 `\n` 문자열로 전달되던 영업시간 정보가 실제 줄바꿈되지 않아 가독성이 떨어졌습니다.  
이를 해결하기 위해 문자열 내 `\n`을 실제 줄바꿈으로 변환하여 표시되도록 변경했습니다.

---

## 🔧 Changes Made

- `StoreDetailPage.jsx` 내 영업시간 문자열 파싱 로직 수정 (`\n` → 실제 줄바꿈 처리)
- 줄바꿈이 적용된 상태에서 텍스트가 보기 좋게 표시되도록 스타일 확인
- 브랜치명: `feature/fix-store-hours-linebreak`

---

## ✅ Related Issues

- 상세페이지 영업시간 표시 오류 개선 요청

---

## 🖼️ Screenshots or Video

> 줄바꿈 전/후 비교가 있다면 첨부

---

## 🧪 Testing

- [x] 여러 줄로 구성된 영업시간이 올바르게 줄바꿈되어 표시되는지 확인
- [x] 모바일에서도 줄바꿈 상태가 레이아웃을 깨지 않는지 확인
- [x] 기타 UI 영향 없음 확인

---

## ✔️ Checklist

- [x] 기능 동작 확인
- [x] 코드 스타일 및 포맷 일관성 확인
- [x] 브라우저 테스트 완료
- [x] Git 커밋 메시지 규칙 준수

---

## 💬 Additional Notes

현재 브라우저에서 영업시간이 정상적으로 줄바꿈되어 표시되고 있습니다.  
변경사항 확인 후 머지 부탁드립니다!
