### PR TITLE
feat: 사용자 역할에 따른 페이지 네비게이션 및 사업자 안내 모달 추가

### DIFF
--- a/src/pages/BusinessPage.jsx
+++ b/src/pages/BusinessPage.jsx
@@ -22,6 +22,13 @@ function BusinessPage() {
   const [toastType, setToastType] = useState('success') // 'success' or 'error'
   const [reservationStatuses, setReservationStatuses] = useState({}) // 예약 상태 저장
 
+  // 사용자 역할 체크
+  useEffect(() => {
+    if (user && user.role === 'BUYER') {
+      navigate('/mypage')
+    }
+  }, [user, navigate])
+
   // 예약 더미 데이터
   const dummyReservations = [
     {

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -27,6 +27,13 @@ function MyPage() {
   const [loading, setLoading] = useState(true)
   const [showLogoutModal, setShowLogoutModal] = useState(false)
 
+  // 사용자 역할 체크
+  useEffect(() => {
+    if (user && user.role === 'SELLER') {
+      navigate('/business')
+    }
+  }, [user, navigate])
+
   // 사용자 정보와 리뷰 목록 가져오기
   useEffect(() => {
     const fetchUserData = async () => {
@@ -68,9 +75,6 @@ function MyPage() {
           // 모든 주문 합치기 (화면에 표시용)
           const allCompletedOrders = [...completedOrders, ...confirmedOrders]
           setCompletedOrders(allCompletedOrders)
-          
-          // 주문 건수와 환경 지표를 API 응답 데이터 기준으로 업데이트하는 코드 제거
-          // 백엔드의 totalProductCount 값을 계속 사용
         }
       } catch (error) {
         console.error('사용자 데이터 로딩 중 오류:', error)

--- a/src/pages/StoreDetailPage.jsx
+++ b/src/pages/StoreDetailPage.jsx
@@ -15,7 +15,7 @@ import { useAuth } from '../context/AuthContext'
 function StoreDetailPage() {
   const { id } = useParams()
   const navigate = useNavigate()
-  const { isLoggedIn, user } = useAuth()
+  const { isLoggedIn, user, logout } = useAuth()
   const [activeTab, setActiveTab] = useState('map')
   const [store, setStore] = useState(null)
   const [showPhonePopup, setShowPhonePopup] = useState(false)
@@ -43,6 +43,7 @@ function StoreDetailPage() {
   const [showSuccessModal, setShowSuccessModal] = useState(false) // 성공 모달 상태 추가
   const [reservationResult, setReservationResult] = useState(null) // 예약 결과 정보 저장
   const [showLoginModal, setShowLoginModal] = useState(false)
+  const [showSellerModal, setShowSellerModal] = useState(false) // 사업자 안내 모달 상태 추가
 
   // Google Maps 이미지 URL인지 확인하는 함수
   const isGoogleMapsImage = (url) => {
@@ -404,6 +405,13 @@ function StoreDetailPage() {
       setShowLoginModal(true)
       return
     }
+
+    // 사업자 예약 제한
+    if (user && user.role === 'SELLER') {
+      setShowSellerModal(true)
+      return
+    }
+
     setShowPhonePopup(true)
   }
 
@@ -1131,6 +1139,61 @@ function StoreDetailPage() {
               <button
                 className="w-full py-2 text-gray-600 font-medium"
                 onClick={() => setShowLoginModal(false)}
+              >
+                취소
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* 사업자 안내 모달 */}
+      {showSellerModal && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-white rounded-lg p-5 w-4/5 max-w-xs">
+            <div className="flex justify-between items-center mb-4">
+              <h3 className="font-bold text-lg">사업자 안내</h3>
+              <button
+                onClick={() => setShowSellerModal(false)}
+                className="p-1 rounded-full hover:bg-gray-100"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="h-5 w-5"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+              </button>
+            </div>
+            
+            <div className="text-center mb-4">
+              <p className="text-gray-600">
+                사업자 계정으로는 예약이 불가능합니다.
+                <br />
+                일반 사용자 계정으로 로그인해주세요.
+              </p>
+            </div>
+            
+            <div className="flex flex-col space-y-2">
+              <button
+                className="w-full py-3 bg-yellow-500 text-white font-bold rounded-lg"
+                onClick={async () => {
+                  await logout()
+                  setShowSellerModal(false)
+                  navigate('/login')
+                }}
+              >
+                로그인하기
+              </button>
+              <button
+                className="w-full py-2 text-gray-600 font-medium"
+                onClick={() => setShowSellerModal(false)}
               >
                 취소
               </button>


### PR DESCRIPTION
# 사업자 예약 제한 및 접근 제어 구현

## 변경사항

### 1. 사업자 예약 제한 기능
- `StoreDetailPage.jsx`에 사업자 안내 모달 추가
- 사업자(SELLER)가 예약하기 버튼 클릭 시 안내 모달 표시
- 안내 메시지: "사업자 계정으로는 예약이 불가능합니다. 일반 사용자 계정으로 로그인해주세요."
- 로그인하기 버튼 클릭 시 자동 로그아웃 후 로그인 페이지로 이동

### 2. 접근 제어 구현
- `MyPage.jsx`: 사업자(SELLER) 접근 시 자동으로 사업자 페이지로 리다이렉션
- `BusinessPage.jsx`: 일반 사용자(BUYER) 접근 시 자동으로 마이페이지로 리다이렉션


## 테스트 방법
1. 사업자 계정으로 로그인
2. 가게 상세 페이지에서 예약하기 버튼 클릭
3. 사업자 안내 모달이 표시되는지 확인
4. 로그인하기 버튼 클릭 시 로그아웃 후 로그인 페이지로 이동하는지 확인
5. 일반 사용자 계정으로 로그인하여 예약이 정상적으로 가능한지 확인

## 관련 이슈
- 사업자 계정으로 예약 시도 시 적절한 안내 메시지 필요
- 사업자/일반 사용자 페이지 접근 제어 구현
