### PR TITLE
fix: 비밀번호 변경 기능 개선 및 검증 로직 강화

### DIFF
--- a/src/pages/EditProfilePage.jsx
+++ b/src/pages/EditProfilePage.jsx
@@ -82,6 +82,12 @@ function EditProfilePage() {
       setCurrentPasswordError('현재 비밀번호를 입력해주세요.')
     } else {
       setCurrentPasswordError('')
+      // 새 비밀번호가 입력되어 있고 현재 비밀번호와 동일한 경우 체크
+      if (newPassword && e.target.value === newPassword) {
+        setPasswordError('새 비밀번호는 현재 비밀번호와 달라야 합니다.')
+      } else if (newPassword && passwordError === '새 비밀번호는 현재 비밀번호와 달라야 합니다.') {
+        setPasswordError('')
+      }
     }
   }
 
@@ -99,21 +105,26 @@ function EditProfilePage() {
     const value = e.target.value
     setNewPassword(value)
 
+    // 새 비밀번호 유효성 검사
     if (!value) {
       setPasswordError('새로운 비밀번호를 입력해주세요.')
     } else if (value.length < 8 || value.length > 20) {
       setPasswordError('비밀번호는 8자 이상, 20자 이하여야 합니다.')
+    } else if (value === currentPassword && currentPassword) {
+      setPasswordError('새 비밀번호는 현재 비밀번호와 달라야 합니다.')
     } else {
       setPasswordError('')
     }
 
     // 비밀번호 확인 일치 여부 검사
-    if (confirmPassword && value !== confirmPassword) {
-      setPasswordsNotMatch(true)
-      setConfirmPasswordError('비밀번호가 일치하지 않습니다.')
-    } else if (confirmPassword) {
-      setPasswordsNotMatch(false)
-      setConfirmPasswordError('')
+    if (confirmPassword) {
+      if (value !== confirmPassword) {
+        setPasswordsNotMatch(true)
+        setConfirmPasswordError('비밀번호가 일치하지 않습니다.')
+      } else {
+        setPasswordsNotMatch(false)
+        setConfirmPasswordError('')
+      }
     }
   }
 
@@ -131,7 +142,10 @@ function EditProfilePage() {
     const value = e.target.value
     setConfirmPassword(value)
 
-    if (value !== newPassword) {
+    if (!value) {
+      setPasswordsNotMatch(false)
+      setConfirmPasswordError('비밀번호 확인을 입력해주세요.')
+    } else if (value !== newPassword) {
       setPasswordsNotMatch(true)
       setConfirmPasswordError('비밀번호가 일치하지 않습니다.')
     } else {
@@ -216,6 +230,16 @@ function EditProfilePage() {
       return
     }
 
+    if (newPassword === currentPassword) {
+      setPasswordError('새 비밀번호는 현재 비밀번호와 달라야 합니다.')
+      return
+    }
+
+    if (!confirmPassword) {
+      setConfirmPasswordError('비밀번호 확인을 입력해주세요.')
+      return
+    }
+
     if (newPassword !== confirmPassword) {
       setPasswordsNotMatch(true)
       setConfirmPasswordError('비밀번호가 일치하지 않습니다.')
@@ -237,7 +261,9 @@ function EditProfilePage() {
         setCurrentPassword('')
         setNewPassword('')
         setConfirmPassword('')
+        setCurrentPasswordError('')
         setPasswordError('')
+        setConfirmPasswordError('')
         setPasswordsNotMatch(false)
         // 수정 완료 시 홈화면으로 이동
         setTimeout(() => {
@@ -349,11 +375,17 @@ function EditProfilePage() {
             value={currentPassword}
             onChange={handleCurrentPasswordChange}
             placeholder="현재 비밀번호를 입력해주세요."
-            className="w-full p-2 bg-gray-100 rounded-lg border border-gray-300 mb-2"
+            className={`w-full p-2 bg-gray-100 rounded-lg border ${
+              currentPasswordError ? 'border-red-500' : 'border-gray-300'
+            } mb-2`}
           />
-          {currentPasswordError && (
+          {currentPasswordError ? (
             <p className="text-red-500 text-sm mb-2">
               * {currentPasswordError}
+            </p>
+          ) : (
+            <p className="text-gray-500 text-xs mb-2">
+              * 현재 사용중인 비밀번호를 입력해주세요.
             </p>
           )}
 
@@ -363,10 +395,16 @@ function EditProfilePage() {
             value={newPassword}
             onChange={handlePasswordChange}
             placeholder="새로운 비밀번호를 입력해주세요."
-            className="w-full p-2 bg-gray-100 rounded-lg border border-gray-300 mb-2"
+            className={`w-full p-2 bg-gray-100 rounded-lg border ${
+              passwordError ? 'border-red-500' : 'border-gray-300'
+            } mb-2`}
           />
-          {passwordError && (
+          {passwordError ? (
             <p className="text-red-500 text-sm mb-2">* {passwordError}</p>
+          ) : (
+            <p className="text-gray-500 text-xs mb-2">
+              * 8~20자의 영문, 숫자, 특수문자를 조합하여 입력해주세요.
+            </p>
           )}
 
           <label className="block text-sm font-medium mb-1">
@@ -377,11 +415,21 @@ function EditProfilePage() {
             value={confirmPassword}
             onChange={handleConfirmPasswordChange}
             placeholder="비밀번호를 다시 한번 입력해주세요."
-            className="w-full p-2 bg-gray-100 rounded-lg border border-gray-300"
+            className={`w-full p-2 bg-gray-100 rounded-lg border ${
+              confirmPasswordError ? 'border-red-500' : 'border-gray-300'
+            }`}
           />
-          {passwordsNotMatch && (
+          {confirmPasswordError ? (
             <p className="text-red-500 text-sm mt-1">
               * {confirmPasswordError}
+            </p>
+          ) : confirmPassword ? (
+            <p className="text-green-500 text-xs mt-1">
+              * 비밀번호가 일치합니다.
+            </p>
+          ) : (
+            <p className="text-gray-500 text-xs mt-1">
+              * 새 비밀번호를 한번 더 입력해주세요.
             </p>
           )}
 
@@ -394,7 +442,8 @@ function EditProfilePage() {
                 !newPassword ||
                 !confirmPassword ||
                 passwordsNotMatch ||
-                !!passwordError
+                !!passwordError ||
+                !!currentPasswordError
               }
               className={`px-4 py-3 rounded-lg w-full ${
                 isLoading ||
@@ -402,7 +451,8 @@ function EditProfilePage() {
                 !newPassword ||
                 !confirmPassword ||
                 passwordsNotMatch ||
-                !!passwordError
+                !!passwordError ||
+                !!currentPasswordError
                   ? 'bg-gray-400 cursor-not-allowed'
                   : 'bg-[#F7B32B] hover:bg-[#E09D18] active:bg-[#D08D08]'
               } text-white font-medium transition-colors`}


### PR DESCRIPTION
### Description

비밀번호 변경 기능에서 사용자 검증 및 피드백 기능을 전반적으로 강화함  
특히, **현재 비밀번호와 새 비밀번호가 동일한 경우**, 사용자에게 명확한 안내를 제공하도록 로직 및 UI를 개선함

### Related Issues

- Resolves #222

### Changes Made

1. **검증 로직 개선**
   - 현재 비밀번호와 새 비밀번호가 같을 경우 실시간 검증 추가
   - 새 비밀번호 유효성 검증: 8~20자 길이 확인
   - 비밀번호 확인 필드의 일치 여부 실시간 검사 및 빈 값 처리

2. **피드백 메시지 개선**
   - 상태별로 동적인 헬퍼 텍스트 출력 (회색 안내 / 빨간 오류 / 초록 성공)
   - 오류 발생 시 필드 테두리 색상 변경 처리

3. **사용자 경험 강화**
   - 한글 입력 차단
   - 비밀번호 입력값 실시간 반영
   - 입력 오류 또는 불일치 상태에서 버튼 비활성화 처리

4. **API 통신 결과 처리**
   - 현재 비밀번호 불일치 시 서버 응답 기반의 오류 메시지 표시
   - 성공 시 토스트 알림, 필드 초기화 및 홈 화면 이동 처리

### Screenshots or Video

<!-- 헬퍼 텍스트 반응, 검증 실패 시 메시지, 성공 시 처리 흐름 화면 첨부 가능 -->

### Testing

1. 현재 비밀번호와 새 비밀번호가 같을 경우 → 실시간 오류 메시지 확인
2. 비밀번호 확인 필드 불일치 → 빨간 메시지 표시 및 버튼 비활성화
3. 길이 제한 위반 → 오류 메시지 표시
4. 입력값이 모두 올바른 경우 → 서버 API 요청 성공 및 성공 메시지 확인
5. 서버 측 비밀번호 불일치 → `"현재 비밀번호가 일치하지 않습니다"` 메시지 확인

### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

### Additional Notes

- 추후 다국어(i18n) 적용 시, 헬퍼 텍스트 및 에러 메시지는 문자열 리소스로 분리 필요
- 한글 입력 차단은 UX 측면에서 선택적일 수 있음 (접근성 고려)
- 비밀번호 강도 검사(숫자/특수문자 포함 여부 등)는 다음 단계에서 확장 가능
