### PR TITLE
style: 토스트 메시지 z-index 수정 및 코드 포맷팅

### DIFF
--- a/src/components/products/ProductManagement.jsx
+++ b/src/components/products/ProductManagement.jsx
@@ -1,6 +1,12 @@
 import React, { useState, useEffect, useRef } from 'react'
 import { useParams } from 'react-router-dom'
-import { getStoreProducts, createProduct, updateProduct, deleteProduct, updateProductStatus } from '../../api/productApi'
+import {
+  getStoreProducts,
+  createProduct,
+  updateProduct,
+  deleteProduct,
+  updateProductStatus,
+} from '../../api/productApi'
 import { getStoreById } from '../../api/storeApi'
 
 const ProductManagement = () => {
@@ -29,7 +35,7 @@ const ProductManagement = () => {
       setLoading(true)
       const data = await getStoreProducts(storeId)
       setProducts(data || [])
-      
+
       // 가게 정보 로드
       const storeData = await getStoreById(storeId)
       if (storeData.success) {
@@ -90,7 +96,7 @@ const ProductManagement = () => {
       ...formData,
       [name]: value,
     })
-    
+
     // 가격 필드인 경우 숫자만 입력되도록 유효성 검사 추가
     if (name === 'originalPrice' || name === 'discountedPrice') {
       if (!/^\d*$/.test(value)) {
@@ -109,18 +115,18 @@ const ProductManagement = () => {
 
   // 재고 증가 처리
   const increaseStock = () => {
-    setFormData(prev => ({
+    setFormData((prev) => ({
       ...prev,
-      stock: Number(prev.stock) + 1
+      stock: Number(prev.stock) + 1,
     }))
   }
 
   // 재고 감소 처리
   const decreaseStock = () => {
     if (formData.stock > 1) {
-      setFormData(prev => ({
+      setFormData((prev) => ({
         ...prev,
-        stock: Number(prev.stock) - 1
+        stock: Number(prev.stock) - 1,
       }))
     }
   }
@@ -160,9 +166,9 @@ const ProductManagement = () => {
   // 상품 추가 또는 수정 제출
   const handleSubmit = async (e) => {
     e.preventDefault()
-    
+
     if (!validateForm()) return
-    
+
     try {
       if (editMode && currentProduct) {
         const updatedFormData = {
@@ -170,30 +176,33 @@ const ProductManagement = () => {
           originalPrice: parseInt(formData.originalPrice),
           discountedPrice: parseInt(formData.discountedPrice),
           description: formData.description,
-          stock: parseInt(formData.stock)
+          stock: parseInt(formData.stock),
         }
-        
+
         await updateProduct(storeId, currentProduct.id, updatedFormData)
         showToast('럭키트가 수정되었습니다.')
       } else {
         if (products.length > 0) {
-          showToast('럭키트는 한 개만 등록 가능합니다. 기존 럭키트를 수정하세요.', 'error')
+          showToast(
+            '럭키트는 한 개만 등록 가능합니다. 기존 럭키트를 수정하세요.',
+            'error',
+          )
           return
         }
-        
+
         const productRequestData = {
           productName: formData.productName,
           originalPrice: parseInt(formData.originalPrice),
           discountedPrice: parseInt(formData.discountedPrice),
           description: formData.description,
           stock: parseInt(formData.stock),
-          isOpen: true // 기본값 추가
+          isOpen: true, // 기본값 추가
         }
-        
+
         await createProduct(storeId, productRequestData)
         showToast('럭키트가 등록되었습니다.')
       }
-      
+
       setIsModalVisible(false)
       loadProducts()
     } catch (error) {
@@ -212,7 +221,7 @@ const ProductManagement = () => {
   const handleDeleteProduct = async () => {
     try {
       if (!currentProduct) return
-      
+
       await deleteProduct(storeId, currentProduct.id)
       showToast('럭키트가 삭제되었습니다.')
       setConfirmModalVisible(false)
@@ -228,15 +237,15 @@ const ProductManagement = () => {
     try {
       const newStatus = !product.isOpen
       const response = await updateProductStatus(storeId, product.id, newStatus)
-      
+
       // response가 직접 상품 데이터를 반환하므로 이를 사용하여 상태 업데이트
       if (response) {
-        setProducts(prevProducts => 
-          prevProducts.map(p => 
-            p.id === product.id ? response : p
-          )
+        setProducts((prevProducts) =>
+          prevProducts.map((p) => (p.id === product.id ? response : p)),
         )
-        showToast(`럭키트가 ${response.isOpen ? '활성화' : '비활성화'} 되었습니다.`)
+        showToast(
+          `럭키트가 ${response.isOpen ? '활성화' : '비활성화'} 되었습니다.`,
+        )
       } else {
         showToast('럭키트 상태 변경에 실패했습니다.', 'error')
       }
@@ -245,22 +254,23 @@ const ProductManagement = () => {
       showToast('럭키트 상태 변경에 실패했습니다.', 'error')
     }
   }
-  
+
   return (
     <div className="p-4">
       <h1 className="text-2xl font-bold text-center mb-6">럭키트 관리</h1>
-      
+
       {/* 럭키트 설명 추가 */}
       <div className="mb-6 bg-[#FFF8E8] p-4 rounded-lg border border-[#F7B32B] text-sm">
         <h3 className="font-bold text-[#F7B32B] mb-2">💡 럭키트란?</h3>
         <p className="text-gray-700 mb-2">
-          하루 영업이 끝나고 남은 음식들을 랜덤으로 한 봉투에 담아 할인된 가격에 판매하는 상품입니다.
+          하루 영업이 끝나고 남은 음식들을 랜덤으로 한 봉투에 담아 할인된 가격에
+          판매하는 상품입니다.
         </p>
         <p className="text-gray-700 font-medium">
           ⚠️ 럭키트는 한 가게당 하나만 등록할 수 있습니다.
         </p>
       </div>
-      
+
       {loading ? (
         <div className="flex justify-center items-center h-32">
           <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-[#F7B32B]"></div>
@@ -275,7 +285,7 @@ const ProductManagement = () => {
               </p>
             </div>
           </div>
-          
+
           {products.length === 0 ? (
             <div className="bg-white rounded-lg shadow-md p-6 text-center">
               <p className="text-gray-500 mb-4">등록된 럭키트가 없습니다.</p>
@@ -298,9 +308,11 @@ const ProductManagement = () => {
                   <div className="p-4">
                     <div className="flex justify-between items-start">
                       <div className="flex items-center">
-                        <div className={`text-white text-xs font-medium px-2 py-1 rounded mr-2 ${
-                          product.isOpen ? 'bg-[#F7B32B]' : 'bg-gray-400'
-                        }`}>
+                        <div
+                          className={`text-white text-xs font-medium px-2 py-1 rounded mr-2 ${
+                            product.isOpen ? 'bg-[#F7B32B]' : 'bg-gray-400'
+                          }`}
+                        >
                           럭키트
                         </div>
                         <h3 className="font-bold text-lg text-gray-800">
@@ -311,7 +323,9 @@ const ProductManagement = () => {
                         onClick={() => toggleProductStatus(product)}
                         className="relative inline-flex items-center h-6 rounded-full w-11 focus:outline-none transition-colors"
                         style={{
-                          backgroundColor: product.isOpen ? '#4ADE80' : '#D1D5DB'
+                          backgroundColor: product.isOpen
+                            ? '#4ADE80'
+                            : '#D1D5DB',
                         }}
                       >
                         <span
@@ -321,7 +335,7 @@ const ProductManagement = () => {
                         />
                       </button>
                     </div>
-                    
+
                     <div className="mt-4">
                       <div className="flex items-baseline">
                         <span className="text-lg font-bold text-red-600">
@@ -331,17 +345,24 @@ const ProductManagement = () => {
                           {product.originalPrice.toLocaleString()}원
                         </span>
                         <span className="ml-2 text-xs text-blue-600">
-                          {Math.round((1 - product.discountedPrice / product.originalPrice) * 100)}% 할인
+                          {Math.round(
+                            (1 -
+                              product.discountedPrice / product.originalPrice) *
+                              100,
+                          )}
+                          % 할인
                         </span>
                       </div>
                     </div>
 
                     <div className="flex justify-between items-center mt-4">
-                      <span className={`inline-block text-xs font-medium px-2.5 py-0.5 rounded-full ${
-                        product.isOpen 
-                          ? 'bg-blue-100 text-blue-800' 
-                          : 'bg-gray-100 text-gray-600'
-                      }`}>
+                      <span
+                        className={`inline-block text-xs font-medium px-2.5 py-0.5 rounded-full ${
+                          product.isOpen
+                            ? 'bg-blue-100 text-blue-800'
+                            : 'bg-gray-100 text-gray-600'
+                        }`}
+                      >
                         재고: {product.productCount || 1}개
                       </span>
                       <div className="flex space-x-2">
@@ -366,7 +387,7 @@ const ProductManagement = () => {
           )}
         </>
       )}
-      
+
       {/* 상품 추가/수정 모달 */}
       {isModalVisible && (
         <div className="fixed inset-0 z-50 overflow-auto bg-black bg-opacity-50 flex items-center justify-center p-4">
@@ -375,7 +396,7 @@ const ProductManagement = () => {
               <h3 className="text-lg font-bold text-gray-900 mb-4">
                 {editMode ? '럭키트 수정' : '럭키트 등록'}
               </h3>
-              
+
               <form onSubmit={handleSubmit}>
                 {/* 패키지명 */}
                 <div className="mb-4">
@@ -391,11 +412,12 @@ const ProductManagement = () => {
                     placeholder="럭키트 이름을 입력하세요"
                   />
                   {errors.productName && (
-                    <p className="text-red-500 text-xs mt-1">{errors.productName}</p>
+                    <p className="text-red-500 text-xs mt-1">
+                      {errors.productName}
+                    </p>
                   )}
                 </div>
-                  
-                
+
                 {/* 가격 정보 */}
                 <div className="grid grid-cols-2 gap-4 mb-4">
                   <div>
@@ -411,10 +433,12 @@ const ProductManagement = () => {
                       placeholder="원가 (원)"
                     />
                     {errors.originalPrice && (
-                      <p className="text-red-500 text-xs mt-1">{errors.originalPrice}</p>
+                      <p className="text-red-500 text-xs mt-1">
+                        {errors.originalPrice}
+                      </p>
                     )}
                   </div>
-                  
+
                   <div>
                     <label className="block text-sm font-medium text-gray-700 mb-1">
                       할인가
@@ -428,18 +452,22 @@ const ProductManagement = () => {
                       placeholder="할인가 (원)"
                     />
                     {errors.discountedPrice && (
-                      <p className="text-red-500 text-xs mt-1">{errors.discountedPrice}</p>
+                      <p className="text-red-500 text-xs mt-1">
+                        {errors.discountedPrice}
+                      </p>
                     )}
                   </div>
                 </div>
-                
+
                 {/* 재고 */}
                 <div className="mb-4">
                   <label className="block text-sm font-medium text-gray-700 mb-1">
                     재고 수량
                   </label>
                   <div className="flex flex-col space-y-2">
-                    <p className="text-sm text-gray-500">현재 재고: {currentProduct?.productCount || 1}개</p>
+                    <p className="text-sm text-gray-500">
+                      현재 재고: {currentProduct?.productCount || 1}개
+                    </p>
                     <div className="flex items-center">
                       <button
                         type="button"
@@ -466,7 +494,7 @@ const ProductManagement = () => {
                     </div>
                   </div>
                 </div>
-                    
+
                 {/* 상품 설명 */}
                 <div className="mb-4">
                   <label className="block text-sm font-medium text-gray-700 mb-1">
@@ -481,10 +509,12 @@ const ProductManagement = () => {
                     placeholder="럭키트에 포함될 수 있는 음식들을 설명해주세요"
                   ></textarea>
                   {errors.description && (
-                    <p className="text-red-500 text-xs mt-1">{errors.description}</p>
+                    <p className="text-red-500 text-xs mt-1">
+                      {errors.description}
+                    </p>
                   )}
                 </div>
-                
+
                 {/* 버튼 */}
                 <div className="flex justify-end space-x-3 mt-6">
                   <button
@@ -506,12 +536,14 @@ const ProductManagement = () => {
           </div>
         </div>
       )}
-      
+
       {/* 삭제 확인 모달 */}
       {confirmModalVisible && (
         <div className="fixed inset-0 z-50 overflow-auto bg-black bg-opacity-50 flex items-center justify-center p-4">
           <div className="bg-white rounded-lg w-full max-w-sm mx-auto p-6">
-            <h3 className="text-lg font-medium text-gray-900 mb-4">럭키트 삭제</h3>
+            <h3 className="text-lg font-medium text-gray-900 mb-4">
+              럭키트 삭제
+            </h3>
             <p className="text-sm text-gray-500 mb-4">
               정말로 이 럭키트를 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.
             </p>
@@ -534,11 +566,11 @@ const ProductManagement = () => {
           </div>
         </div>
       )}
-      
+
       {/* 토스트 메시지 */}
       {toast.show && (
         <div
-          className={`fixed bottom-20 left-1/2 transform -translate-x-1/2 px-4 py-2 rounded-lg shadow-lg ${
+          className={`fixed bottom-20 left-1/2 transform -translate-x-1/2 px-4 py-2 rounded-lg shadow-lg z-100 ${
             toast.type === 'error' ? 'bg-red-500' : 'bg-green-500'
           } text-white text-sm`}
         >
@@ -549,4 +581,4 @@ const ProductManagement = () => {
   )
 }
 
-export default ProductManagement 
+export default ProductManagement

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,7 +4,18 @@ export default {
   theme: {
     extend: {
       fontFamily: {
-        sans: ['"Pretendard Variable"', 'Pretendard', '-apple-system', 'BlinkMacSystemFont', 'system-ui', 'Roboto', '"Helvetica Neue"', 'Arial', '"Noto Sans"', 'sans-serif'],
+        sans: [
+          '"Pretendard Variable"',
+          'Pretendard',
+          '-apple-system',
+          'BlinkMacSystemFont',
+          'system-ui',
+          'Roboto',
+          '"Helvetica Neue"',
+          'Arial',
+          '"Noto Sans"',
+          'sans-serif',
+        ],
         noto: ['"Noto Sans KR"', 'sans-serif'],
         display: ['"Black Han Sans"', 'sans-serif'],
       },
@@ -24,22 +35,30 @@ export default {
           DEFAULT: '#8D6E63',
           dark: '#4E342E',
         },
-        'bread': {
+        bread: {
           light: '#FFF8E1',
           crust: '#D4A76A',
           brown: '#A87C4F',
-        }
+        },
       },
       backgroundImage: {
         'jeju-pattern': "url('/src/assets/images/jeju-pattern.png')",
       },
       boxShadow: {
-        'soft': '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)',
-        'hover': '0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)',
+        soft: '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)',
+        hover:
+          '0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)',
       },
       borderRadius: {
-        'xl': '1rem',
+        xl: '1rem',
         '2xl': '1.5rem',
+      },
+      zIndex: {
+        60: '60',
+        70: '70',
+        80: '80',
+        90: '90',
+        100: '100',
       },
     },
   },


### PR DESCRIPTION
### Description

럭키트 저장 실패 시 토스트 메시지가 모달 뒤에 가려지는 현상을 수정했습니다.
스크린샷 참고해주세요!

### Related Issues

- Resolves #270

### Changes Made

1. 토스트 메시지의 z-index를 100으로 수정하여 모달(z-index: 50) 위에 표시되도록 변경
2. tailwind.config.js에 z-index 관련 설정 추가 (60~100)
3. Prettier를 통한 코드 포맷팅 적용

### Screenshots or Video

<img width="512" alt="스크린샷 2025-04-04 오전 1 38 10" src="https://github.com/user-attachments/assets/268ea574-98a8-49af-a9af-e1d2cc07e590" />

<img width="441" alt="스크린샷 2025-04-04 오전 1 38 59" src="https://github.com/user-attachments/assets/1e1eb4b1-5bf7-46f5-99b7-e886c9a7a5ce" />

### Testing

1. 럭키트 관리 페이지에서 럭키트 등록/수정/삭제 시 토스트 메시지가 모달 위에 정상적으로 표시되는지 확인
2. 모달이 열린 상태에서도 토스트 메시지가 가려지지 않고 잘 보이는지 확인
3. 테스트 환경: MacOS, Chrome 브라우저

### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

### Additional Notes

토스트 메시지의 z-index 값을 100으로 설정한 이유는 현재 사용 중인 가장 높은 z-index 값이 50(모달)이기 때문입니다. 
향후 더 높은 z-index가 필요한 컴포넌트가 추가될 경우 이 값을 조정할 수 있습니다.
해당 코드외에 수정사항(내용변경없음)은 lint format을 돌려서 그런겁니다..