### PR TITLE
258 가게주소복사기능 UI개선

### DIFF
--- a/src/pages/StoreDetailPage.jsx
+++ b/src/pages/StoreDetailPage.jsx
@@ -216,6 +216,12 @@ function StoreDetailPage() {
     }
   }, [])
 
+  // 주소에서 '대한민국' 제거하는 함수 추가
+  const removeCountryFromAddress = (address) => {
+    if (!address) return '주소 정보 없음'
+    return address.replace(/^대한민국\s+/, '')
+  }
+
   // 주소 복사 기능 추가
   const handleCopyClick = () => {
     if (!store?.address) return
@@ -605,7 +611,7 @@ function StoreDetailPage() {
 
           {/* 지도 아래에 주소 표시 및 복사 기능 추가 */}
           <div className="mt-2 flex items-center justify-between bg-gray-100 p-2 rounded-md">
-            <span className="text-gray-700">{store.address || '주소 정보 없음'}</span>
+            <span className="text-gray-700">{removeCountryFromAddress(store.address)}</span>
             <button
               onClick={handleCopyClick}
               className="ml-2 flex items-center text-blue-500 hover:text-blue-600 transition-colors"

--- a/src/pages/StoreDetailPage.jsx
+++ b/src/pages/StoreDetailPage.jsx
@@ -604,12 +604,36 @@ function StoreDetailPage() {
           </div>
 
           {/* 지도 아래에 주소 표시 및 복사 기능 추가 */}
-          <div
-            className="mt-2 text-center text-gray-700 cursor-pointer bg-gray-100 p-2 rounded-md hover:bg-gray-200 transition"
-            onClick={handleCopyClick}
-          >
-            {store.address || '주소 정보 없음'}
+          <div className="mt-2 flex items-center justify-between bg-gray-100 p-2 rounded-md">
+            <span className="text-gray-700">{store.address || '주소 정보 없음'}</span>
+            <button
+              onClick={handleCopyClick}
+              className="ml-2 flex items-center text-blue-500 hover:text-blue-600 transition-colors"
+              title="주소 복사하기"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-5 w-5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+                />
+              </svg>
+            </button>
           </div>
+
+          {/* 복사 성공 메시지 */}
+          {copySuccess && (
+            <div className="fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 bg-black bg-opacity-75 text-white px-4 py-2 rounded-lg z-50">
+              복사되었습니다!
+            </div>
+          )}
 
           {/* 카카오맵으로 보기 및 길찾기 버튼 */}
           {store.latitude && store.longitude && (


### PR DESCRIPTION
### Description

가게 상세 페이지의 주소 복사 기능의 UI를 개선하고, 주소 표시에서 '대한민국'을 제거했습니다.

### Related Issues

- Resolves #258

### Changes Made

1. 주소 복사 UI 개선
   - 복사 아이콘을 표시하도록 수정

2. 주소 표시 개선
   - 주소에서 '대한민국' 텍스트 자동 제거 기능 추가

3. 복사 성공 메시지 개선
   - 화면 중앙에 고정된 위치로 표시
   - 반투명 검은 배경과 흰색 텍스트로 가시성 향상


이전
<img width="380" alt="스크린샷 2025-04-04 오전 2 59 07" src="https://github.com/user-attachments/assets/acefd387-3d7f-49ab-9657-325f95cb07b1" />

이후
<img width="376" alt="스크린샷 2025-04-04 오전 2 59 51" src="https://github.com/user-attachments/assets/70ca991b-0467-41bc-8481-bc7907329443" />

### Testing

1. 주소 복사 기능 테스트
   - 주소 클릭 시 클립보드에 복사되는지 확인
   - 복사 성공 메시지가 표시되는지 확인
   - 복사된 주소가 정확한지 확인

2. 주소 표시 테스트
   - '대한민국'이 포함된 주소에서 자동으로 제거되는지 확인
   - 주소가 없는 경우 '주소 정보 없음'이 표시되는지 확인

3. UI 테스트
   - 복사 아이콘에 마우스를 올렸을 때 툴팁이 표시되는지 확인
   - 호버 효과가 정상적으로 작동하는지 확인

### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

### Additional Notes

주소 복사기능이 있다는 것을 이슈로 처음알았습니다..