### PR TITLE
지도 페이지 API 엔드포인트 수정: 모든 가게 데이터 한 번에 로드

### DIFF
--- a/src/pages/MapPage.jsx
+++ b/src/pages/MapPage.jsx
@@ -255,7 +255,7 @@ function MapPage() {
         // 가게 데이터 가져오기
         try {
           // 할인중인 가게만 보여주기 옵션이 선택된 경우 API 파라미터 추가
-          let apiUrl = `/api/v1/stores`
+          let apiUrl = `${API_BASE_URL}/stores`
           
           // URL 매개변수 객체 생성
           const params = new URLSearchParams()
@@ -264,6 +264,10 @@ function MapPage() {
           if (showDiscountOnly) {
             params.append('isDiscountOpen', 'true')
           }
+          
+          // 전체 가게 데이터를 한 번에 가져오기 위한 큰 size 값 설정
+          params.append('size', '1000')
+          params.append('page', '0')
           
           // 매개변수가 있으면 URL에 추가
           if (params.toString()) {


### PR DESCRIPTION
### Description

- 지도 페이지(`MapPage`)에서 전체 가게 데이터를 불러올 때 사용하는 API 요청을 개선했습니다.
- 기존 하드코딩된 `/api/v1/stores` 경로를 상수화된 `API_BASE_URL`을 사용하는 방식으로 변경했습니다.
- 페이지네이션 기본값(`page=0`, `size=1000`)을 명시적으로 추가하여 한 번에 최대 1000개의 가게 데이터를 가져올 수 있도록 최적화했습니다.

---



### Changes Made

1. API 요청 경로를 상수(`API_BASE_URL`) 기반으로 동적으로 구성
  
   // 변경 전
   let apiUrl = '/api/v1/stores'

   // 변경 후
   let apiUrl = `${API_BASE_URL}/stores`



2.전체 가게 데이터를 한 번에 불러오기 위해 쿼리 파라미터 추가
params.append('size', '1000')
params.append('page', '0')
할인중인 가게만 필터링 옵션이 활성화된 경우 isDiscountOpen=true를 함께 추가