### PR TITLE
StoreDetailPage에서 남은 수량 표시 로직 개선: 제품이 열려있지 않거나 수량이 0일 경우 남은 수량 텍스트를 숨김

### DIFF
--- a/src/pages/StoreDetailPage.jsx
+++ b/src/pages/StoreDetailPage.jsx
@@ -690,7 +690,11 @@ function StoreDetailPage() {
 
                   <div className="flex items-center mb-3">
                     <span className="text-sm text-gray-600">
-                      남은 수량: <span className="font-bold text-yellow-600">{productInfo.productCount || 0}개</span>
+                      {!productInfo.isOpen || productInfo.productCount === 0 ? (
+                        ''
+                      ) : (
+                        <>남은 수량: <span className="font-bold text-yellow-600">{productInfo.productCount || 0}개</span></>
+                      )}
                     </span>
                   </div>
 


### PR DESCRIPTION
### Description

상품 상태가 close거나 재고가 0일 시 재고수량 안보이도록 수정


### Related Issues

- closes #344


### Screenshots or Video

<img width="504" alt="image" src="https://github.com/user-attachments/assets/619e6bac-845e-4bf5-ab94-ee0ce56b553f" />


### Testing

크롬에서 테스트 완료 


### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

### Additional Notes

<!--
  리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요.
-->
