### PR TITLE
333 사업자 가입시 가게 승인을 기다려주세요 같은 안내문구가 필요함

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,6 +20,7 @@ import EditStorePage from './pages/EditStorePage'
 import StoreReservationsPage from './pages/StoreReservationsPage'
 import UserReservationsPage from './pages/UserReservationsPage'
 import NotFoundPage from './pages/NotFoundPage'
+import NoRegisteredStorePage from './pages/NoRegisteredStorePage'
 import { AuthProvider, useAuth } from './context/AuthContext'
 import * as Sentry from '@sentry/react'
 import { hasValidAccessToken } from './utils/jwtUtils'
@@ -98,6 +99,7 @@ function AppRoutes() {
         <Route path="/edit-store" element={<EditStorePage />} />
         <Route path="/store/:storeId/reservation" element={<StoreReservationsPage />} />
         <Route path="/reservation" element={<UserReservationsPage />} />
+        <Route path="/no-registered-store" element={<NoRegisteredStorePage />} />
         <Route path="*" element={<NotFoundPage />} />
       </Routes>
     </AuthWrapper>

--- a/src/pages/BusinessPage.jsx
+++ b/src/pages/BusinessPage.jsx
@@ -113,6 +113,10 @@ function BusinessPage() {
         // 가게 정보 가져오기
         const storeResponse = await getMyStore()
         if (storeResponse.success) {
+          if (!storeResponse.data || !storeResponse.data.id) {
+            navigate('/no-registered-store')
+            return
+          }
           setStoreData(storeResponse.data)
           console.log('가게 정보:', storeResponse.data)
           
@@ -138,7 +142,7 @@ function BusinessPage() {
     if (user) {
       fetchData()
     }
-  }, [user])
+  }, [user, navigate])
 
   // 예약 상태 업데이트 (승인/거절)
   const handleReservationStatus = async (reservationId, status) => {
@@ -310,12 +314,13 @@ function BusinessPage() {
                   <button
                     className="w-full text-left font-bold text-gray-700 flex justify-between items-center"
                     onClick={() => {
-                      if (storeData) {
+                      if (storeData && storeData.id) {
                         console.log('가게 상세보기 이동:', storeData.id);
                         navigate(`/store/${storeData.id}`);
+                      } else {
+                        navigate('/no-registered-store');
                       }
                     }}
-                    disabled={!storeData}
                   >
                     <span>가게 상세보기</span>
                     <span className="text-gray-400">→</span>
@@ -326,12 +331,13 @@ function BusinessPage() {
                   <button
                     className="w-full text-left font-bold text-gray-700 flex justify-between items-center"
                     onClick={() => {
-                      if (storeData) {
+                      if (storeData && storeData.id) {
                         console.log('럭키트 관리 이동:', storeData.id);
                         navigate(`/store/${storeData.id}/products`);
+                      } else {
+                        navigate('/no-registered-store');
                       }
                     }}
-                    disabled={!storeData}
                   >
                     <span>럭키트 관리</span>
                     <span className="text-gray-400">→</span>
@@ -342,12 +348,13 @@ function BusinessPage() {
                   <button
                     className="w-full text-left font-bold text-gray-700 flex justify-between items-center"
                     onClick={() => {
-                      if (storeData) {
+                      if (storeData && storeData.id) {
                         console.log('가게 예약 리스트 이동:', storeData.id);
                         navigate(`/store/${storeData.id}/reservation`);
+                      } else {
+                        navigate('/no-registered-store');
                       }
                     }}
-                    disabled={!storeData}
                   >
                     <span>가게 예약 리스트</span>
                     <span className="text-gray-400">→</span>

--- a/src/pages/EditStorePage.jsx
+++ b/src/pages/EditStorePage.jsx
@@ -55,52 +55,52 @@ function EditStorePage() {
     const fetchStoreData = async () => {
       try {
         const response = await getMyStore()
-        if (response.success) {
-          setStore(response.data)
-          setFormData({
-            storeName: response.data.storeName || '',
-            storeImg: response.data.storeImg || '',
-            address: response.data.address || '',
-            website: response.data.website || '',
-            storeUrl: response.data.storeUrl || '',
-            permissionUrl: response.data.permissionUrl || '',
-            latitude: response.data.latitude || 0,
-            longitude: response.data.longitude || 0,
-            contactNumber: response.data.contactNumber || '',
-            description: response.data.description || '',
-            businessNumber: response.data.businessNumber || '',
-            businessHours: response.data.businessHours || '',
-            pickupTime: response.data.pickupTime || '',
-            avgRating: response.data.avgRating || 0,
-            avgRatingGoogle: response.data.avgRatingGoogle || 0,
-            googlePlaceId: response.data.googlePlaceId || '',
-          })
-          setImagePreview(response.data.storeImg || '')
-          if (response.data.businessHours) {
-            const times = response.data.businessHours.split(' - ')
-            if (times.length === 2) {
-              setTimeRange({
-                openTime: times[0],
-                closeTime: times[1]
-              })
-            }
+        if (!response.success || !response.data || !response.data.id) {
+          navigate('/no-registered-store')
+          return
+        }
+        setStore(response.data)
+        setFormData({
+          storeName: response.data.storeName || '',
+          storeImg: response.data.storeImg || '',
+          address: response.data.address || '',
+          website: response.data.website || '',
+          storeUrl: response.data.storeUrl || '',
+          permissionUrl: response.data.permissionUrl || '',
+          latitude: response.data.latitude || 0,
+          longitude: response.data.longitude || 0,
+          contactNumber: response.data.contactNumber || '',
+          description: response.data.description || '',
+          businessNumber: response.data.businessNumber || '',
+          businessHours: response.data.businessHours || '',
+          pickupTime: response.data.pickupTime || '',
+          avgRating: response.data.avgRating || 0,
+          avgRatingGoogle: response.data.avgRatingGoogle || 0,
+          googlePlaceId: response.data.googlePlaceId || '',
+        })
+        setImagePreview(response.data.storeImg || '')
+        if (response.data.businessHours) {
+          const times = response.data.businessHours.split(' - ')
+          if (times.length === 2) {
+            setTimeRange({
+              openTime: times[0],
+              closeTime: times[1]
+            })
           }
-          
-          if (response.data.pickupTime) {
-            const pickupTimes = response.data.pickupTime.split(' - ')
-            if (pickupTimes.length === 2) {
-              setPickupTimeRange({
-                startTime: pickupTimes[0],
-                endTime: pickupTimes[1]
-              })
-            }
+        }
+        
+        if (response.data.pickupTime) {
+          const pickupTimes = response.data.pickupTime.split(' - ')
+          if (pickupTimes.length === 2) {
+            setPickupTimeRange({
+              startTime: pickupTimes[0],
+              endTime: pickupTimes[1]
+            })
           }
-        } else {
-          setError('가게 정보를 불러오는데 실패했습니다.')
         }
       } catch (error) {
-        setError('가게 정보를 불러오는데 실패했습니다.')
         console.error('가게 정보 로딩 중 오류:', error)
+        navigate('/no-registered-store')
       } finally {
         setLoading(false)
       }
@@ -109,7 +109,7 @@ function EditStorePage() {
     if (user) {
       fetchStoreData()
     }
-  }, [user])
+  }, [user, navigate])
 
   const handleInputChange = (e) => {
     const { name, value } = e.target
@@ -244,7 +244,6 @@ function EditStorePage() {
     } catch (error) {
       setError('가게 정보 수정 중 오류가 발생했습니다.')
       showToastMessage('가게 정보 수정 중 오류가 발생했습니다.')
-      console.error('가게 정보 수정 중 오류:', error)
     } finally {
       setLoading(false)
     }

--- a/src/pages/NoRegisteredStorePage.jsx
+++ b/src/pages/NoRegisteredStorePage.jsx
@@ -1,0 +1,62 @@
+import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import luckeatDefaultImage from '../assets/images/luckeat_default_image.webp';
+import Header from '../components/layout/Header';
+import Navigation from '../components/layout/Navigation';
+
+const NoRegisteredStorePage = () => {
+  const navigate = useNavigate();
+
+  // 뒤로가기 방지
+  useEffect(() => {
+    const preventGoBack = (e) => {
+      e.preventDefault();
+      // 대신 비즈니스 페이지로 이동
+      navigate('/business');
+    };
+    
+    window.history.pushState(null, "", window.location.pathname);
+    window.addEventListener('popstate', preventGoBack);
+    
+    return () => {
+      window.removeEventListener('popstate', preventGoBack);
+    };
+  }, [navigate]);
+
+  return (
+    <div className="flex flex-col h-full">
+      <Header title="가게 정보" />
+      <div className="flex-1 flex flex-col items-center justify-start pt-12 px-4 bg-gray-50 overflow-y-auto">
+        <div className="w-full max-w-md text-center space-y-6">
+          <img
+            src={luckeatDefaultImage}
+            alt="럭킷 기본 이미지"
+            className="mx-auto w-64 h-64 object-contain"
+          />
+          <div className="space-y-4">
+            <h1 className="text-2xl font-bold text-gray-900">등록된 가게가 없습니다</h1>
+            <p className="text-lg text-gray-600">
+              가게 등록을 원하시면{' '}
+              <a
+                href="mailto:luckeatnet@gmail.com"
+                className="text-yellow-500 hover:text-yellow-600 font-semibold"
+              >
+                luckeatnet@gmail.com
+              </a>
+              로 연락주세요!
+            </p>
+          </div>
+          <button
+            onClick={() => navigate('/business')}
+            className="mt-8 px-6 py-3 bg-yellow-500 text-white rounded-md hover:bg-yellow-600 transition-colors"
+          >
+            비즈니스 페이지로 돌아가기
+          </button>
+        </div>
+      </div>
+      <Navigation />
+    </div>
+  );
+};
+
+export default NoRegisteredStorePage; 

--- a/src/pages/NoRegisteredStorePage.jsx
+++ b/src/pages/NoRegisteredStorePage.jsx
@@ -50,7 +50,7 @@ const NoRegisteredStorePage = () => {
             onClick={() => navigate('/business')}
             className="mt-8 px-6 py-3 bg-yellow-500 text-white rounded-md hover:bg-yellow-600 transition-colors"
           >
-            비즈니스 페이지로 돌아가기
+            사업자 페이지로 돌아가기
           </button>
         </div>
       </div>

--- a/src/pages/ProductManagementPage.jsx
+++ b/src/pages/ProductManagementPage.jsx
@@ -1,9 +1,32 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import Header from '../components/layout/Header'
 import Navigation from '../components/layout/Navigation'
 import ProductManagement from '../components/products/ProductManagement'
+import { getMyStore } from '../api/storeApi'
+import { useNavigate } from 'react-router-dom'
 
 const ProductManagementPage = () => {
+  const navigate = useNavigate()
+  const [storeData, setStoreData] = useState(null)
+
+  useEffect(() => {
+    const fetchStoreData = async () => {
+      try {
+        const response = await getMyStore()
+        if (!response.success || !response.data || !response.data.id) {
+          navigate('/no-registered-store')
+          return
+        }
+        setStoreData(response.data)
+      } catch (error) {
+        console.error('가게 정보 로딩 중 오류:', error)
+        navigate('/no-registered-store')
+      }
+    }
+
+    fetchStoreData()
+  }, [navigate])
+
   return (
     <div className="flex flex-col h-full">
       <Header title="상품 관리" />

--- a/src/pages/StoreReservationsPage.jsx
+++ b/src/pages/StoreReservationsPage.jsx
@@ -8,6 +8,7 @@ import {
   getStoreReservations,
   updateReservationStatus,
 } from '../api/reservationApi'
+import { getMyStore } from '../api/storeApi'
 
 const ReservationStatusBadge = ({ status }) => {
   let bgColor = 'bg-gray-200'
@@ -56,6 +57,7 @@ const StoreReservationsPage = () => {
   const [toastType, setToastType] = useState('success') // 'success' or 'error'
   const [expandedReservationId, setExpandedReservationId] = useState(null)
   const [activeFilter, setActiveFilter] = useState('ALL')
+  const [storeData, setStoreData] = useState(null)
 
   useEffect(() => {
     const verifyAuth = async () => {
@@ -76,6 +78,24 @@ const StoreReservationsPage = () => {
 
     verifyAuth()
   }, [navigate, storeId, checkCurrentAuthStatus])
+
+  useEffect(() => {
+    const fetchStoreData = async () => {
+      try {
+        const response = await getMyStore()
+        if (!response.success || !response.data || !response.data.id) {
+          navigate('/no-registered-store')
+          return
+        }
+        setStoreData(response.data)
+      } catch (error) {
+        console.error('가게 정보 로딩 중 오류:', error)
+        navigate('/no-registered-store')
+      }
+    }
+
+    fetchStoreData()
+  }, [navigate])
 
   const fetchReservations = async () => {
     try {


### PR DESCRIPTION
### Description

사업자 회원이 로그인했지만 등록된 가게 정보가 없는 경우,
- `/no-registered-store` 안내 페이지로 리디렉션되며
- "가게 등록을 위해 luckeatnet@gmail.com 으로 연락주세요"라는 문구를 보여줍니다.
- 뒤로가기로 비즈니스 페이지로 돌아가지 않도록 popstate를 활용하여 차단했습니다.

---

### Related Issues

- Resolves #333

---

### Changes Made

1. `NoRegisteredStorePage` 페이지 신규 생성
   - 가게 미등록 상태 안내 메시지 및 이메일 링크 포함
   - 뒤로가기 시 비즈니스 페이지로 강제 이동 처리

2. 주요 페이지 접근 시 가게 등록 여부 확인 로직 추가
   - `BusinessPage`, `EditStorePage`, `ProductManagementPage`, `StoreReservationsPage` 등
   - `getMyStore()` 호출 결과가 없거나 `store.id`가 없을 경우 `/no-registered-store`로 이동

3. 라우트 등록
   ```js
   <Route path="/no-registered-store" element={<NoRegisteredStorePage />} />
