### PR TITLE
Feature/business page route

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,6 +25,8 @@ import { AuthProvider, useAuth } from './context/AuthContext'
 import * as Sentry from '@sentry/react'
 import { hasValidAccessToken } from './utils/jwtUtils'
 import Navigation from './components/layout/Navigation'
+import { getMyStore } from './api/storeApi'
+
 // 오류 발생 시 보여줄 폴백 컴포넌트
 const FallbackComponent = () => {
   return (
@@ -58,7 +60,7 @@ const detectSafari = () => {
 
 // 토큰 유효성 검사 래퍼 컴포넌트
 function AuthWrapper({ children }) {
-  const { checkCurrentAuthStatus } = useAuth()
+  const { checkCurrentAuthStatus, user } = useAuth()
   const navigate = useNavigate()
   const location = useLocation()
 
@@ -87,15 +89,50 @@ function AuthWrapper({ children }) {
     }
   }, [location.pathname, checkCurrentAuthStatus, navigate, location])
 
+  // 가게 관련 경로 체크
+  useEffect(() => {
+    const checkStoreAccess = async () => {
+      try {
+        const storeResponse = await getMyStore()
+        const hasStore = storeResponse.success && storeResponse.data
+
+        // 가게 관련 경로 목록
+        const storePaths = [
+          '/store/:id',
+          '/store/:storeId/products',
+          '/edit-store',
+          '/store/:storeId/reservation'
+        ]
+
+        // 현재 경로가 가게 관련 경로인지 확인
+        const isStorePath = storePaths.some((path) => {
+          const regex = new RegExp('^' + path.replace(/:[^/]+/g, '[^/]+') + '$')
+          return regex.test(location.pathname)
+        })
+
+        // 가게가 없고 가게 관련 경로에 접근하려는 경우
+        if (!hasStore && isStorePath) {
+          navigate('/no-registered-store', { replace: true })
+        }
+      } catch (error) {
+        console.error('가게 정보 확인 중 오류:', error)
+      }
+    }
+
+    if (user) {
+      checkStoreAccess()
+    }
+  }, [location.pathname, user, navigate])
+
   return children
 }
 
 // 네비게이션 바가 필요한지 확인하는 함수
 const shouldShowNavigation = (pathname) => {
   // 네비게이션 바를 표시하지 않을 경로 목록
-  const hideNavigationPaths = ['/login', '/signup'];
-  return !hideNavigationPaths.includes(pathname);
-};
+  const hideNavigationPaths = ['/login', '/signup']
+  return !hideNavigationPaths.includes(pathname)
+}
 
 function AppRoutes() {
   const location = useLocation();

--- a/src/pages/BusinessPage.jsx
+++ b/src/pages/BusinessPage.jsx
@@ -223,6 +223,15 @@ function BusinessPage() {
   // API에서 가져온 사용자 정보가 없으면, 로컬 상태의 사용자 정보 사용
   const displayUser = userData || user || {}
 
+  // 가게 관련 페이지로 이동하는 핸들러
+  const handleStorePageNavigation = (path) => {
+    if (storeData) {
+      navigate(path);
+    } else {
+      navigate('/no-registered-store');
+    }
+  };
+
   return (
     <div className="flex flex-col h-full">
       {/* 헤더 */}
@@ -311,11 +320,11 @@ function BusinessPage() {
                     className="w-full text-left font-bold text-gray-700 flex justify-between items-center"
                     onClick={() => {
                       if (storeData) {
-                        console.log('가게 상세보기 이동:', storeData.id);
                         navigate(`/store/${storeData.id}`);
+                      } else {
+                        navigate('/no-registered-store');
                       }
                     }}
-                    disabled={!storeData}
                   >
                     <span>가게 상세보기</span>
                     <span className="text-gray-400">→</span>
@@ -327,11 +336,11 @@ function BusinessPage() {
                     className="w-full text-left font-bold text-gray-700 flex justify-between items-center"
                     onClick={() => {
                       if (storeData) {
-                        console.log('럭키트 관리 이동:', storeData.id);
                         navigate(`/store/${storeData.id}/products`);
+                      } else {
+                        navigate('/no-registered-store');
                       }
                     }}
-                    disabled={!storeData}
                   >
                     <span>럭키트 관리</span>
                     <span className="text-gray-400">→</span>
@@ -343,11 +352,11 @@ function BusinessPage() {
                     className="w-full text-left font-bold text-gray-700 flex justify-between items-center"
                     onClick={() => {
                       if (storeData) {
-                        console.log('가게 예약 리스트 이동:', storeData.id);
                         navigate(`/store/${storeData.id}/reservation`);
+                      } else {
+                        navigate('/no-registered-store');
                       }
                     }}
-                    disabled={!storeData}
                   >
                     <span>가게 예약 리스트</span>
                     <span className="text-gray-400">→</span>
@@ -357,7 +366,13 @@ function BusinessPage() {
                 <div className="border-b pb-2">
                   <button
                     className="w-full text-left font-bold text-gray-700 flex justify-between items-center"
-                    onClick={() => navigate('/edit-store')}
+                    onClick={() => {
+                      if (storeData) {
+                        navigate('/edit-store');
+                      } else {
+                        navigate('/no-registered-store');
+                      }
+                    }}
                   >
                     <span>가게 정보 수정</span>
                     <span className="text-gray-400">→</span>

--- a/src/pages/NoRegisteredStorePage.jsx
+++ b/src/pages/NoRegisteredStorePage.jsx
@@ -28,7 +28,7 @@ function NoRegisteredStorePage() {
         <img
           src={storeDefaultImage}
           alt="기본 이미지"
-          className="w-40 h-40 object-cover rounded-lg mb-6"
+          className="w-20 h-25 object-cover rounded-lg mb-6"
         />
         
         <h2 className="text-xl font-bold mb-4">
@@ -43,7 +43,7 @@ function NoRegisteredStorePage() {
           onClick={() => navigate('/business')}
           className="px-6 py-2 bg-yellow-500 text-white font-medium rounded-lg shadow"
         >
-          비즈니스 페이지로 돌아가기
+          사업자 페이지로 돌아가기
         </button>
       </div>
     </div>

--- a/src/pages/StoreDetailPage.jsx
+++ b/src/pages/StoreDetailPage.jsx
@@ -473,7 +473,7 @@ function StoreDetailPage() {
     store.products?.filter((product) => !product.isOpen) || []
 
   return (
-    <div className="flex flex-col h-full relative">
+    <div className="flex flex-col h-full">
       <Header title={store.storeName} />
 
       <div
@@ -873,7 +873,8 @@ function StoreDetailPage() {
             <div>
               {/* 리뷰 평점 */}
               <div className="mb-4">
-                <p className="text-3xl font-bold text-center mb-2">
+                <p className="text-3xl font-bold text-center mb-2 flex items-center justify-center">
+                  <span className="text-yellow-500 mr-1">★</span>
                   {(
                     store.reviews.reduce((acc, review) => acc + review.rating, 0) /
                     store.reviews.length
@@ -912,18 +913,7 @@ function StoreDetailPage() {
                     </div>
                   </div>
 
-                  {/* 상품 정보 */}
-                  <div className="mt-2 p-2 bg-gray-50 rounded">
-                    <p className="text-sm text-gray-700">
-                      <span className="font-medium">{review.productName}</span>
-                      <span className="mx-2">·</span>
-                      <span>{review.quantity}개</span>
-                    </p>
-                    <p className="text-sm text-gray-700 mt-1">
-                      <span className="font-medium">주문 금액</span>
-                      <span className="ml-2">{review.totalPrice.toLocaleString()}원</span>
-                    </p>
-                  </div>
+
 
                   {review.reviewImage && (
                     <div className="my-2">
@@ -1283,7 +1273,6 @@ function StoreDetailPage() {
           </div>
         </div>
       )}
-
     </div>
   )
 }

--- a/src/pages/StoreDetailPage.jsx
+++ b/src/pages/StoreDetailPage.jsx
@@ -473,7 +473,7 @@ function StoreDetailPage() {
     store.products?.filter((product) => !product.isOpen) || []
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col h-full relative">
       <Header title={store.storeName} />
 
       <div
@@ -873,8 +873,7 @@ function StoreDetailPage() {
             <div>
               {/* 리뷰 평점 */}
               <div className="mb-4">
-                <p className="text-3xl font-bold text-center mb-2 flex items-center justify-center">
-                  <span className="text-yellow-500 mr-1">★</span>
+                <p className="text-3xl font-bold text-center mb-2">
                   {(
                     store.reviews.reduce((acc, review) => acc + review.rating, 0) /
                     store.reviews.length
@@ -913,7 +912,18 @@ function StoreDetailPage() {
                     </div>
                   </div>
 
-
+                  {/* 상품 정보 */}
+                  <div className="mt-2 p-2 bg-gray-50 rounded">
+                    <p className="text-sm text-gray-700">
+                      <span className="font-medium">{review.productName}</span>
+                      <span className="mx-2">·</span>
+                      <span>{review.quantity}개</span>
+                    </p>
+                    <p className="text-sm text-gray-700 mt-1">
+                      <span className="font-medium">주문 금액</span>
+                      <span className="ml-2">{review.totalPrice.toLocaleString()}원</span>
+                    </p>
+                  </div>
 
                   {review.reviewImage && (
                     <div className="my-2">
@@ -1273,6 +1283,8 @@ function StoreDetailPage() {
           </div>
         </div>
       )}
+
+      <Navigation />
     </div>
   )
 }

--- a/src/pages/StoreDetailPage.jsx
+++ b/src/pages/StoreDetailPage.jsx
@@ -1284,7 +1284,6 @@ function StoreDetailPage() {
         </div>
       )}
 
-      <Navigation />
     </div>
   )
 }


### PR DESCRIPTION
### Description

가게가 없는 사용자가 가게 관련 페이지에 접근할 경우, 등록된 가게가 없다는 안내 페이지(`/no-registered-store`)로 리디렉션되도록 라우팅 처리함  
가게가 없는 경우에도 안정적인 사용자 경험을 보장하기 위해 페이지 진입 전 선제적으로 확인하고, 안내 메시지를 통해 유도함

---


### Changes Made

1. `App.jsx` - `AuthWrapper`에 가게 정보 존재 여부 검사 로직 추가
   - 가게 관련 경로(`edit-store`, `store/:id`, `products`, `reservation`) 접근 시 가게 정보 없으면 `/no-registered-store`로 이동
2. `BusinessPage.jsx` - 각 버튼 클릭 시 `storeData` 유무에 따라 조건 분기 처리 (중복 로직 제거 및 간결화)
3. `NoRegisteredStorePage.jsx` - 기본 이미지 사이즈 및 버튼 문구 조정 (`비즈니스 페이지` → `사업자 페이지`)
4. `StoreDetailPage.jsx` 등 기타 파일 포맷 정리 및 코드 복원 처리

---

### Screenshots or Video

- 가게 정보가 없는 계정으로 로그인 시, 관련 경로 접근 시 `/no-registered-store` 페이지로 자동 리디렉션 되는 플로우 확인
- 안내 메시지 및 "사업자 페이지로 돌아가기" 버튼 클릭 시 정상 이동

---

### Testing

1. 가게 미등록 계정으로 로그인
   - `/edit-store`, `/store/:id`, `/store/:id/products`, `/store/:id/reservation` 경로 접근 → 자동 리디렉션 확인
2. 가게 등록된 계정으로 로그인


---

### Checklist

- [x] 가게 없는 계정에서 접근 제어 정상 동작 확인
- [x] 관련 페이지 접근 시 UI 레이아웃 깨짐 없음
- [x] 가게가 있는 계정에서 기존 기능 정상 작동 확인
- [x] 중복 라우팅 처리 코드 정리됨
- [x] Navigation 구조 및 기존 PR과 충돌 없음


