### PR TITLE
fix: 탭 클릭 시 스크롤 동작 수정 및 인디케이터 이슈 해결

### DIFF
--- a/src/pages/StoreDetailPage.jsx
+++ b/src/pages/StoreDetailPage.jsx
@@ -45,6 +45,7 @@ function StoreDetailPage() {
   const [showSellerModal, setShowSellerModal] = useState(false) // 사업자 안내 모달 상태 추가
   const [modalQuantity, setModalQuantity] = useState(1)
   const [stockError, setStockError] = useState('')
+  const [isScrolling, setIsScrolling] = useState(false)
 
   // Google Maps 이미지 URL인지 확인하는 함수
   const isGoogleMapsImage = (url) => {
@@ -267,22 +268,72 @@ function StoreDetailPage() {
 
   // 스크롤 관련 함수
   const handleScroll = () => {
-    // 스크롤 이벤트는 유지하되 맨 위로 버튼 관련 코드 제거
+    if (!mainContainerRef.current || isScrolling) return
+
+    const container = mainContainerRef.current
+    const scrollTop = container.scrollTop
+    const containerHeight = container.clientHeight
+    const offset = 100 // 탭 전환 위치 조정을 위한 오프셋
+
+    // 각 섹션의 위치 계산
+    const sections = {
+      map: mapRef.current?.getBoundingClientRect().top,
+      products: productsRef.current?.getBoundingClientRect().top,
+      storeInfo: storeInfoRef.current?.getBoundingClientRect().top,
+      reviews: reviewsRef.current?.getBoundingClientRect().top
+    }
+
+    // 현재 보이는 섹션 찾기
+    const currentSection = Object.entries(sections).reduce((visible, [key, value]) => {
+      if (value && value <= containerHeight * 0.3) {
+        return key
+      }
+      return visible
+    }, 'map')
+
+    // activeTab이 현재 섹션과 다를 때만 업데이트
+    if (!isScrolling && activeTab !== currentSection) {
+      setActiveTab(currentSection)
+    }
   }
 
   // 탭 클릭 시 해당 섹션으로 스크롤
   const handleTabClick = (tab) => {
     setActiveTab(tab)
+    setIsScrolling(true)
     setTimeout(() => {
+      const container = mainContainerRef.current
+      const offset = 100 // 상단 여백 추가
+
       if (tab === 'map' && mapRef.current) {
-        mapRef.current.scrollIntoView({ behavior: 'smooth' })
+        const elementTop = mapRef.current.offsetTop - offset
+        container.scrollTo({
+          top: elementTop,
+          behavior: 'smooth'
+        })
       } else if (tab === 'products' && productsRef.current) {
-        productsRef.current.scrollIntoView({ behavior: 'smooth' })
+        const elementTop = productsRef.current.offsetTop - offset
+        container.scrollTo({
+          top: elementTop,
+          behavior: 'smooth'
+        })
       } else if (tab === 'storeInfo' && storeInfoRef.current) {
-        storeInfoRef.current.scrollIntoView({ behavior: 'smooth' })
+        const elementTop = storeInfoRef.current.offsetTop - offset
+        container.scrollTo({
+          top: elementTop,
+          behavior: 'smooth'
+        })
       } else if (tab === 'reviews' && reviewsRef.current) {
-        reviewsRef.current.scrollIntoView({ behavior: 'smooth' })
+        const elementTop = reviewsRef.current.offsetTop - offset
+        container.scrollTo({
+          top: elementTop,
+          behavior: 'smooth'
+        })
       }
+      // 스크롤 애니메이션이 끝난 후 isScrolling 상태 해제
+      setTimeout(() => {
+        setIsScrolling(false)
+      }, 500)
     }, 100)
   }
 


### PR DESCRIPTION
### Description

가게 상세 페이지의 탭 클릭 시 스크롤 동작과 인디케이터 이슈를 해결했습니다. (스크롤과 인디케이터가 맞지않는 이슈)
각 섹션의 제목이 잘 보이도록 스크롤 위치를 조정하고, 스크롤 중 탭 인디케이터가 잘못된 위치로 이동하는 문제를 수정했습니다.

### Related Issues

- Closes #332

### Changes Made

1. 탭 클릭 시 스크롤 동작 수정
   - 각 섹션의 제목이 잘 보이도록 스크롤 위치 조정 (상단 100px 여백 추가)
   - `mainContainerRef.scrollTo` 사용하여 스크롤 동작 개선
   - 모든 탭(지도, 럭키트 정보, 가게 정보, 리뷰)에 대해 동일한 스크롤 로직 적용

2. 탭 인디케이터 이슈 해결
   - `isScrolling` 상태를 추가하여 스크롤 애니메이션 중 탭 변경 방지
   - 스크롤 위치 감지 로직 개선 (`offsetTop` 사용)
   - 각 섹션의 위치를 정확하게 계산하여 탭 전환 안정성 향상

### Screenshots or Video

스크롤을 내릴 때 인디케이터도 변함

### Testing

1. 각 탭 클릭 시 동작 테스트
   - 지도 탭 클릭 → "위치 정보" 제목이 상단에 보이도록 스크롤
   - 럭키트 정보 탭 클릭 → "럭키트 정보" 제목이 상단에 보이도록 스크롤
   - 가게 정보 탭 클릭 → "기본 정보" 제목이 상단에 보이도록 스크롤
   - 리뷰 탭 클릭 → "리뷰" 제목이 상단에 보이도록 스크롤

2. 스크롤 중 인디케이터 동작 테스트
   - 지도 탭 클릭 시 인디케이터가 다른 탭으로 이동했다가 돌아오는 현상 해결 확인
   - 리뷰 탭 클릭 시 인디케이터가 가게 정보로 이동했다가 돌아오는 현상 해결 확인

### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

### Additional Notes

스크롤 이벤트와 탭 클릭 이벤트의 충돌을 해결하기 위해 `isScrolling` 상태를 사용했습니다. 
스크롤 애니메이션이 완료될 때까지(500ms) 탭 변경이 일어나지 않도록 처리했습니다.