### PR TITLE
feat: Sentry self-hosted 서버로 이관

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,27 +3,20 @@ import ReactDOM from 'react-dom/client'
 import App from './App'
 import './index.css'
 import * as Sentry from '@sentry/react'
-import { BrowserTracing } from '@sentry/tracing'
-import { Replay } from '@sentry/replay'
 
 // Sentry 초기화
 Sentry.init({
   dsn: import.meta.env.VITE_SENTRY_DSN,
   integrations: [
-    new BrowserTracing(),
-    new Replay({
-      // 세션 리플레이 설정
-      maskAllText: false,
-      blockAllMedia: false,
-    }),
+    Sentry.browserTracingIntegration(),
+    Sentry.replayIntegration(),
   ],
-  // 성능 추적 샘플링 비율 (0.0 ~ 1.0)
-  tracesSampleRate: import.meta.env.PROD ? 0.2 : 1.0,
-  // 세션 리플레이 샘플링 비율
-  replaysSessionSampleRate: import.meta.env.PROD ? 0.1 : 1.0,
-  // 오류 발생 시 세션 리플레이 샘플링 비율
+  // Tracing
+  tracesSampleRate: 1.0,
+  tracePropagationTargets: ['localhost', /^https:\/\/luckeat\.com/],
+  // Session Replay
+  replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1.0,
-
   // 환경 설정
   environment: import.meta.env.MODE || 'development',
 })


### PR DESCRIPTION
### Description

Sentry를 self-hosted 서버로 이관하고 관련 설정을 업데이트했습니다.

### Related Issues

- Closes #371

### Changes Made

1. Sentry SDK 설정 업데이트
   - self-hosted 서버 DSN 설정
   - 환경 변수를 통한 DSN 관리 구성
   - browserTracingIntegration, replayIntegration 설정 업데이트
2. Sentry 트레이싱 설정 업데이트
   - tracesSampleRate: 100% 캡처
   - tracePropagationTargets: localhost, luckeat.com 도메인 설정
3. 세션 리플레이 설정 구성
   - replaysSessionSampleRate: 10%
   - replaysOnErrorSampleRate: 100%

### Testing

1. 로컬 개발 환경에서 Sentry 초기화 확인
   - 환경 변수 정상 로드 확인
   - Sentry SDK 초기화 성공 확인
2. 에러 트래킹 테스트
   - 테스트 에러 발생 시 Sentry 대시보드에서 정상적으로 에러 수집 확인
3. 환경 변수 설정 검증
   - .env.development 파일을 통한 로컬 환경 설정 확인
   - .gitignore에 환경 변수 파일 제외 설정 확인

### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] Sentry SDK가 정상적으로 초기화되는지 확인했습니다.
- [x] 환경 변수가 올바르게 설정되었는지 확인했습니다.
- [x] .gitignore에 환경 변수 파일이 포함되어 있는지 확인했습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 코드 리뷰어를 지정하였습니다.

### Additional Notes

self-hosted Sentry 서버 주소: sentry.yimtaejong.com
환경 변수는 GitHub Secrets에 `SENTRY_DSN`으로 설정되어 있으며, 빌드 시 `VITE_SENTRY_DSN`으로 주입됩니다.