### PR TITLE
feat: Sentry 개발 환경 URL 추가

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -13,7 +13,11 @@ Sentry.init({
   ],
   // Tracing
   tracesSampleRate: 1.0,
-  tracePropagationTargets: ['localhost', /^https:\/\/luckeat\.com/],
+  tracePropagationTargets: [
+    'localhost',
+    /^https:\/\/luckeat\.com/,
+    /^https:\/\/dxa66rf338pjr\.cloudfront\.net/,
+  ],
   // Session Replay
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1.0,


### PR DESCRIPTION
### Description

이전 PR #372 에서 개발환경 url (https://dxa66rf338pjr.cloudfront.net/)을 추가하였습니다. 
아래 PR내용은 이전과 동일합니다.

---

Sentry를 self-hosted 서버로 이관하고 관련 설정을 업데이트했습니다. 개발 환경과 운영 환경 모두에서 에러 트래킹이 가능하도록 설정했습니다.

### Related Issues

- Resolves #371

### Changes Made

1. Sentry SDK 설정 업데이트
   - self-hosted 서버 DSN 설정 (sentry.yimtaejong.com)
   - 환경 변수를 통한 DSN 관리 구성 (VITE_SENTRY_DSN)
   - browserTracingIntegration, replayIntegration 설정 업데이트

2. Sentry 트레이싱 설정 업데이트
   - tracesSampleRate: 100% 캡처
   - tracePropagationTargets 설정:
     - localhost (로컬 개발)
     - luckeat.com (운영 환경)
     - dxa66rf338pjr.cloudfront.net (개발 환경)

3. 세션 리플레이 설정 구성
   - replaysSessionSampleRate: 10%
   - replaysOnErrorSampleRate: 100% (에러 발생 시)

### Testing

1. 로컬 개발 환경 테스트
   - 환경 변수 정상 로드 확인
   - Sentry SDK 초기화 성공 확인
   - 테스트 에러 발생 시 정상 수집 확인

2. 개발 환경 테스트 (dxa66rf338pjr.cloudfront.net)
   - 에러 트래킹 정상 작동 확인
   - 트레이싱 설정 적용 확인

3. 환경 변수 설정 검증
   - .env.development 파일을 통한 로컬 환경 설정 확인
   - .gitignore에 환경 변수 파일 제외 설정 확인

### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] Sentry SDK가 정상적으로 초기화되는지 확인했습니다.
- [x] 환경 변수가 올바르게 설정되었는지 확인했습니다.
- [x] .gitignore에 환경 변수 파일이 포함되어 있는지 확인했습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드리뷰어를 지정하였습니다.

### Additional Notes

- self-hosted Sentry 서버 주소: sentry.yimtaejong.com
- 환경 변수는 GitHub Secrets에 `SENTRY_DSN`으로 설정되어 있으며, 빌드 시 `VITE_SENTRY_DSN`으로 주입됩니다.
- 개발 환경과 운영 환경 모두에서 에러 트래킹이 가능하도록 tracePropagationTargets을 설정했습니다.