### PR TITLE
371 센트리 self hosted 로 이관

### DIFF
--- a/.github/workflows/s3-deploy.yml
+++ b/.github/workflows/s3-deploy.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - dev
+      - 371-센트리-self-hosted-로-이관
 
 jobs:
   deploy:

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,6 +25,7 @@ import { AuthProvider, useAuth } from './context/AuthContext'
 import * as Sentry from '@sentry/react'
 import { hasValidAccessToken } from './utils/jwtUtils'
 import Navigation from './components/layout/Navigation'
+
 // 오류 발생 시 보여줄 폴백 컴포넌트
 const FallbackComponent = () => {
   return (
@@ -50,11 +51,11 @@ const FallbackComponent = () => {
 
 // 사파리 감지 함수
 const detectSafari = () => {
-  const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+  const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent)
   if (isSafari) {
-    document.body.classList.add('safari-browser');
+    document.body.classList.add('safari-browser')
   }
-};
+}
 
 // 토큰 유효성 검사 래퍼 컴포넌트
 function AuthWrapper({ children }) {
@@ -65,9 +66,7 @@ function AuthWrapper({ children }) {
   useEffect(() => {
     // 현재 경로가 인증이 필요하지 않은 경로인지 확인
     const publicPaths = ['/login', '/signup', '/', '/home', '/map']
-    
     const isStoreDetailPath = /^\/store\/[^/]+$/.test(location.pathname)
-   
     const isPublicPath = publicPaths.includes(location.pathname) || isStoreDetailPath
 
     // 인증이 필요한 경로에서만 토큰 유효성 검사
@@ -80,7 +79,7 @@ function AuthWrapper({ children }) {
           replace: true,
           state: {
             from: location.pathname,
-            message: '로그인이 필요하거나 로그인 세션이 만료되었습니다. 다시 로그인해 주세요.',
+            message: '로그인이 필요하거나 로그인 세션이 만료되었습니다. 다시 로그인해 주세요.'
           },
         })
       }
@@ -93,12 +92,12 @@ function AuthWrapper({ children }) {
 // 네비게이션 바가 필요한지 확인하는 함수
 const shouldShowNavigation = (pathname) => {
   // 네비게이션 바를 표시하지 않을 경로 목록
-  const hideNavigationPaths = [];
-  return !hideNavigationPaths.includes(pathname);
-};
+  const hideNavigationPaths = []
+  return !hideNavigationPaths.includes(pathname)
+}
 
 function AppRoutes() {
-  const location = useLocation();
+  const location = useLocation()
   
   return (
     <AuthWrapper>
@@ -136,8 +135,8 @@ function App() {
         fallback={<FallbackComponent />}
         showDialog
         beforeCapture={(scope) => {
-          scope.setTag("location", window.location.href)
-          scope.setExtra("state", "error_boundary_triggered")
+          scope.setTag('location', window.location.href)
+          scope.setExtra('state', 'error_boundary_triggered')
         }}
       >
         <Router>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -126,14 +126,20 @@ function AppRoutes() {
 }
 
 function App() {
-  // 사파리 감지 후 클래스 추가
   useEffect(() => {
-    detectSafari();
-  }, []);
+    detectSafari()
+  }, [])
 
   return (
     <AuthProvider>
-      <Sentry.ErrorBoundary fallback={<FallbackComponent />}>
+      <Sentry.ErrorBoundary
+        fallback={<FallbackComponent />}
+        showDialog
+        beforeCapture={(scope) => {
+          scope.setTag("location", window.location.href)
+          scope.setExtra("state", "error_boundary_triggered")
+        }}
+      >
         <Router>
           <div className="flex justify-center items-center min-h-screen h-full bg-bread-light">
             <div className="w-[390px] md:h-screen h-[100vh] max-h-[100vh] md:max-h-screen sm:max-h-[775px] bg-white flex flex-col overflow-auto relative shadow-hover border border-jeju-stone-light app-container pb-[50px]">
@@ -146,4 +152,4 @@ function App() {
   )
 }
 
-export default Sentry.withProfiler(App)
+export default Sentry.withProfiler(App, { name: 'LuckEatApp' })

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -15,21 +15,17 @@ console.log('Current Environment:', {
 Sentry.init({
   // 기본 설정
   dsn: import.meta.env.VITE_SENTRY_DSN,
-  debug: true,
+  debug: false,
   environment: import.meta.env.MODE || 'development',
   
   // Error Monitoring 설정
   enabled: true,
   autoSessionTracking: true,
   sendClientReports: true,
-  beforeSend(event) {
-    console.log('Sending event to Sentry:', event)
-    return event
-  },
 
   // 도메인 설정
   allowUrls: [
-    'http://localhost:5173',
+    'http://localhost:3000',
     'https://dxa66rf338pjr.cloudfront.net',
     'https://luckeat.com'
   ],
@@ -38,7 +34,7 @@ Sentry.init({
   // Performance Monitoring 설정
   tracesSampleRate: 1.0,
   tracePropagationTargets: [
-    'http://localhost:5173',
+    'http://localhost:3000',
     'https://dxa66rf338pjr.cloudfront.net',
     'https://luckeat.com'
   ],
@@ -51,7 +47,7 @@ Sentry.init({
   integrations: [
     new Sentry.BrowserTracing({
       tracePropagationTargets: [
-        'http://localhost:5173',
+        'http://localhost:3000',
         'https://dxa66rf338pjr.cloudfront.net',
         'https://luckeat.com'
       ],
@@ -65,29 +61,6 @@ Sentry.init({
   // 릴리즈 정보
   release: '1.0.0',
 })
-
-// Sentry 초기화 확인
-console.log('Sentry Initialized:', {
-  client: Sentry.getCurrentHub().getClient(),
-  options: Sentry.getCurrentHub().getClient()?.getOptions(),
-})
-
-// 테스트 에러 발생
-setTimeout(() => {
-  try {
-    throw new Error('Sentry 테스트 에러')
-  } catch (error) {
-    Sentry.captureException(error, {
-      tags: {
-        environment: import.meta.env.MODE,
-        test: 'true',
-      },
-      extra: {
-        type: 'manual_test',
-      },
-    })
-  }
-}, 2000)
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,6 +4,13 @@ import App from './App'
 import './index.css'
 import * as Sentry from '@sentry/react'
 
+// 환경 변수 확인
+console.log('Current Environment:', {
+  MODE: import.meta.env.MODE,
+  VITE_SENTRY_DSN: import.meta.env.VITE_SENTRY_DSN ? 'exists' : 'missing',
+  BASE_URL: import.meta.env.BASE_URL,
+})
+
 // Sentry 초기화
 Sentry.init({
   dsn: import.meta.env.VITE_SENTRY_DSN,
@@ -23,6 +30,13 @@ Sentry.init({
   replaysOnErrorSampleRate: 1.0,
   // 환경 설정
   environment: import.meta.env.MODE || 'development',
+  debug: true,
+})
+
+// Sentry 초기화 확인
+console.log('Sentry Initialized:', {
+  client: Sentry.getCurrentHub().getClient(),
+  options: Sentry.getCurrentHub().getClient()?.getOptions(),
 })
 
 ReactDOM.createRoot(document.getElementById('root')).render(

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,12 +4,12 @@ import App from './App'
 import './index.css'
 import * as Sentry from '@sentry/react'
 
-// 환경 변수 확인
-console.log('Current Environment:', {
-  MODE: import.meta.env.MODE,
-  VITE_SENTRY_DSN: import.meta.env.VITE_SENTRY_DSN ? 'exists' : 'missing',
-  BASE_URL: import.meta.env.BASE_URL,
-})
+// // 환경 변수 확인
+// console.log('Current Environment:', {
+//   MODE: import.meta.env.MODE,
+//   VITE_SENTRY_DSN: import.meta.env.VITE_SENTRY_DSN ? 'exists' : 'missing',
+//   BASE_URL: import.meta.env.BASE_URL,
+// })
 
 // Sentry 초기화
 Sentry.init({

--- a/src/pages/StoreDetailPage.jsx
+++ b/src/pages/StoreDetailPage.jsx
@@ -58,7 +58,7 @@ function StoreDetailPage() {
 
     // 구글 이미지 URL인 경우 CORS 이슈가 있을 수 있으므로 특별히 처리
     if (isGoogleMapsImage(imageUrl)) {
-      console.log('구글 맵스 이미지 URL 감지:', imageUrl)
+      // console.log('구글 맵스 이미지 URL 감지:', imageUrl)
 
       // 가게 이름이 있으면 그에 맞는 일반적인 이미지를 표시
       // 예: 베이커리 가게인 경우 베이커리 이미지
@@ -119,22 +119,22 @@ function StoreDetailPage() {
       try {
         setLoading(true)
         setError(null)
-        console.log(`가게 상세 정보 요청 - 가게 ID: ${id}`)
+        // console.log(`가게 상세 정보 요청 - 가게 ID: ${id}`)
 
         const response = await getStoreById(id)
-        console.log('가게 상세 정보 응답:', response)
+        // console.log('가게 상세 정보 응답:', response)
 
         if (response.success) {
           const storeData = response.data
 
           // 이미지 URL 확인 및 디버깅
-          console.log('가게 이미지 URL:', storeData.storeImg)
+          // console.log('가게 이미지 URL:', storeData.storeImg)
 
           // 이미지 미리 로드 시도
           if (storeData.storeImg) {
             const img = new Image()
             img.onload = () => {
-              console.log('이미지 미리 로드 성공:', storeData.storeImg)
+              // console.log('이미지 미리 로드 성공:', storeData.storeImg)
             }
             img.onerror = () => {
               console.error('이미지 미리 로드 실패:', storeData.storeImg)
@@ -146,15 +146,15 @@ function StoreDetailPage() {
 
           // 구글 이미지인지 확인
           if (isGoogleMapsImage(storeData.storeImg)) {
-            console.log('구글 맵스 이미지 URL 감지됨')
+            // console.log('구글 맵스 이미지 URL 감지됨')
           }
 
           // JSON으로 응답 객체 로깅 (민감 정보 제외)
           const safeStoreData = { ...storeData }
-          console.log('가게 데이터:', JSON.stringify(safeStoreData, null, 2))
+          // console.log('가게 데이터:', JSON.stringify(safeStoreData, null, 2))
 
           setStore(storeData)
-          console.log('지도 정보:', storeData.latitude, storeData.longitude) // 디버깅용
+          // console.log('지도 정보:', storeData.latitude, storeData.longitude) // 디버깅용
           // 맵 로드 완료 처리
           setMapLoaded(true)
         } else {
@@ -206,12 +206,12 @@ function StoreDetailPage() {
 
       script.onload = () => {
         window.kakao.maps.load(() => {
-          console.log('카카오맵 API 로드 완료')
+          // console.log('카카오맵 API 로드 완료')
           setMapLoaded(true)
         })
       }
     } else {
-      console.log('카카오맵 API가 이미 로드되어 있습니다.')
+      // console.log('카카오맵 API가 이미 로드되어 있습니다.')
       setMapLoaded(true)
     }
   }, [])
@@ -365,8 +365,8 @@ function StoreDetailPage() {
         return
       }
 
-      console.log('출발 위치:', startLocation)
-      console.log('도착 위치:', { lat: store.latitude, lng: store.longitude })
+      // console.log('출발 위치:', startLocation)
+      // console.log('도착 위치:', { lat: store.latitude, lng: store.longitude })
 
       // 카카오맵 길찾기 URL 생성 (출발지->목적지)
       const kakaoMapDirectUrl = `https://map.kakao.com/link/from/내 위치,${startLocation.lat},${startLocation.lng}/to/${store.storeName},${store.latitude},${store.longitude}`
@@ -423,7 +423,7 @@ function StoreDetailPage() {
         isZerowaste: isZerowaste
       }
       
-      console.log('예약 요청 데이터:', reservationData)
+      // console.log('예약 요청 데이터:', reservationData)
       
       // 예약 API 호출
       const result = await createReservation(id, reservationData)


### PR DESCRIPTION
### Description

Sentry를 self-hosted 서버로 이관하고, 에러 모니터링 설정을 개선했습니다.
추가적으로 가게 상세조회 페이지에서 나타나는 불필요한 콘솔로그를 제거하였습니다.

### Related Issues

- Closes #371

### Changes Made

1. Sentry DSN을 self-hosted 서버로 변경
2. Sentry 도메인 설정 추가
   - localhost:3000
   - dxa66rf338pjr.cloudfront.net
   - luckeat.com
3. Sentry 설정 개선
   - debug 모드 비활성화
   - Session Replay 설정 추가
   - Performance Monitoring 설정 추가

### Testing

1. 로컬 환경 테스트
   - 런타임 에러 발생 시 Sentry 캡처 확인
   - Promise 에러 발생 시 Sentry 캡처 확인
   - React 렌더링 에러 발생 시 ErrorBoundary 동작 확인

2. 개발 서버 테스트 (dxa66rf338pjr.cloudfront.net)
   - 실제 환경에서 에러 캡처 동작 확인
   - ErrorBoundary 폴백 UI 표시 확인

### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

### Additional Notes

- Sentry self-hosted 서버: https://sentry.yimtaejong.com
- 에러 발생 시 Sentry 대시보드에서 확인 가능

<img width="1512" alt="스크린샷 2025-04-23 오전 12 38 20" src="https://github.com/user-attachments/assets/09a4c41b-eb62-4eee-96d2-5e640b52e3d0" />
개발자도구에서 확인되는 콘솔로그 제거하였습니다.


